### PR TITLE
Flushing DataOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/src/main/java/org/apache/commons/bcel6/generic/InstructionList.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/InstructionList.java
@@ -955,6 +955,7 @@ public class InstructionList implements Iterable<InstructionHandle> {
                 Instruction i = ih.getInstruction();
                 i.dump(out); // Traverse list
             }
+            out.flush();
         } catch (IOException e) {
             System.err.println(e);
             return new byte[0];


### PR DESCRIPTION
When a DataOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the DataOutputStream before invoking the underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).