### PR TITLE
BCEL6 compatibility to 5.2 snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.externalToolBuilders/
+/.settings/
+/bin/
+/target/
+/.classpath
+/.project
+/maven-eclipse.xml

--- a/src/main/java/org/apache/bcel/Const.java
+++ b/src/main/java/org/apache/bcel/Const.java
@@ -2204,7 +2204,7 @@ public final class Const {
       return ATTRIBUTE_NAMES[index];
   }
 
-  /** Constants used in the StackMap attribute.
+  /** Constants used in the StackMapTable attribute.
    */
   public static final byte ITEM_Bogus      = 0;
   public static final byte ITEM_Integer    = 1;
@@ -2231,7 +2231,7 @@ public final class Const {
       return ITEM_NAMES[index];
   }
 
-  /** Constants used to identify StackMapEntry types.
+  /** Constants used to identify StackMapTableEntry types.
    *
    * For those types which can specify a range, the
    * constant names the lowest value.

--- a/src/main/java/org/apache/bcel/Constants.java
+++ b/src/main/java/org/apache/bcel/Constants.java
@@ -1657,16 +1657,19 @@ public interface Constants {
   public static final byte ATTR_PMG                                     = 9;
   public static final byte ATTR_SIGNATURE                               = 10;
   public static final byte ATTR_STACK_MAP                               = 11;
-  public static final byte ATTR_RUNTIMEVISIBLE_ANNOTATIONS              = 12;
-  public static final byte ATTR_RUNTIMEINVISIBLE_ANNOTATIONS            = 13;
-  public static final byte ATTR_RUNTIMEVISIBLE_PARAMETER_ANNOTATIONS    = 14;
-  public static final byte ATTR_RUNTIMEINVISIBLE_PARAMETER_ANNOTATIONS  = 15;
+  public static final byte ATTR_RUNTIME_VISIBLE_ANNOTATIONS             = 12;
+  public static final byte ATTR_RUNTIME_INVISIBLE_ANNOTATIONS           = 13;
+  public static final byte ATTR_RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS   = 14;
+  public static final byte ATTR_RUNTIME_INVISIBLE_PARAMETER_ANNOTATIONS = 15;
   public static final byte ATTR_ANNOTATION_DEFAULT                      = 16;
+  public static final byte ATTR_LOCAL_VARIABLE_TYPE_TABLE               = 17;
+  public static final byte ATTR_ENCLOSING_METHOD                        = 18;
+  public static final byte ATTR_STACK_MAP_TABLE                         = 19;
+  public static final byte ATTR_BOOTSTRAP_METHODS                       = 20;
+  public static final byte ATTR_METHOD_PARAMETERS                       = 21;
 
-  public static final short KNOWN_ATTRIBUTES = 12;//should be 17
+  public static final short KNOWN_ATTRIBUTES = 22; // count of attributes
 
-
-  // TODO: mutable public array!!
   public static final String[] ATTRIBUTE_NAMES = {
     "SourceFile", "ConstantValue", "Code", "Exceptions",
     "LineNumberTable", "LocalVariableTable",
@@ -1674,10 +1677,11 @@ public interface Constants {
     "PMGClass", "Signature", "StackMap",
     "RuntimeVisibleAnnotations", "RuntimeInvisibleAnnotations",
     "RuntimeVisibleParameterAnnotations", "RuntimeInvisibleParameterAnnotations",
-    "AnnotationDefault"
+    "AnnotationDefault", "LocalVariableTypeTable", "EnclosingMethod", "StackMapTable",
+    "BootstrapMethods", "MethodParameters"
   };
 
-  /** Constants used in the StackMap attribute.
+  /** Constants used in the StackMapTable attribute.
    */
   public static final byte ITEM_Bogus      = 0;
   public static final byte ITEM_Integer    = 1;

--- a/src/main/java/org/apache/bcel/classfile/Attribute.java
+++ b/src/main/java/org/apache/bcel/classfile/Attribute.java
@@ -251,7 +251,7 @@ public abstract class Attribute implements Cloneable, Node {
             case Const.ATTR_ENCLOSING_METHOD:
                 return new EnclosingMethod(name_index, length, file, constant_pool);
             case Const.ATTR_STACK_MAP_TABLE:
-                return new StackMap(name_index, length, file, constant_pool);
+                return new StackMapTable(name_index, length, file, constant_pool);
             case Const.ATTR_BOOTSTRAP_METHODS:
                 return new BootstrapMethods(name_index, length, file, constant_pool);
             case Const.ATTR_METHOD_PARAMETERS:

--- a/src/main/java/org/apache/bcel/classfile/DescendingVisitor.java
+++ b/src/main/java/org/apache/bcel/classfile/DescendingVisitor.java
@@ -250,6 +250,7 @@ public class DescendingVisitor implements Visitor
 
     /**
      * @since 6.0
+     */
     @Override
     public void visitStackMapTable(StackMapTable table)
     {
@@ -261,10 +262,10 @@ public class DescendingVisitor implements Visitor
         }
         stack.pop();
     }
-     */
 
     /**
      * @since 6.0
+     */
     @Override
     public void visitStackMapTableEntry(StackMapTableEntry var)
     {
@@ -272,7 +273,6 @@ public class DescendingVisitor implements Visitor
         var.accept(visitor);
         stack.pop();
     }
-     */
 
     @Override
     public void visitLocalVariable(final LocalVariable var)

--- a/src/main/java/org/apache/bcel/classfile/EmptyVisitor.java
+++ b/src/main/java/org/apache/bcel/classfile/EmptyVisitor.java
@@ -237,19 +237,19 @@ public class EmptyVisitor implements Visitor
 
     /**
      * @since 6.0
+     */
     @Override
     public void visitStackMapTable(StackMapTable obj)
     {
     }
-     */
 
     /**
      * @since 6.0
+     */
     @Override
     public void visitStackMapTableEntry(StackMapTableEntry obj)
     {
     }
-     */
 
     /**
      * @since 6.0

--- a/src/main/java/org/apache/bcel/classfile/StackMapTable.java
+++ b/src/main/java/org/apache/bcel/classfile/StackMapTable.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.bcel.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.bcel.Const;
+
+/**
+ * This class represents a stack map attribute used for
+ * preverification of Java classes for the <a
+ * href="http://java.sun.com/j2me/"> Java 2 Micro Edition</a>
+ * (J2ME). This attribute is used by the <a
+ * href="http://java.sun.com/products/cldc/">KVM</a> and contained
+ * within the Code attribute of a method. See CLDC specification
+ * �5.3.1.2
+ *
+ * @version $Id$
+ * @see     Code
+ * @see     StackMapTableEntry
+ * @see     StackMapType
+ */
+public final class StackMapTable extends Attribute {
+
+    private StackMapTableEntry[] map; // Table of stack map entries
+
+
+    /*
+     * @param name_index Index of name
+     * @param length Content length in bytes
+     * @param map Table of stack map entries
+     * @param constant_pool Array of constants
+     */
+    public StackMapTable(final int name_index, final int length, final StackMapTableEntry[] map, final ConstantPool constant_pool) {
+        super(Const.ATTR_STACK_MAP, name_index, length, constant_pool);
+        this.map = map;
+    }
+
+
+    /**
+     * Construct object from input stream.
+     * 
+     * @param name_index Index of name
+     * @param length Content length in bytes
+     * @param input Input stream
+     * @param constant_pool Array of constants
+     * @throws IOException
+     */
+    StackMapTable(final int name_index, final int length, final DataInput input, final ConstantPool constant_pool) throws IOException {
+        this(name_index, length, (StackMapTableEntry[]) null, constant_pool);
+        int map_length = input.readUnsignedShort();
+        map = new StackMapTableEntry[map_length];
+        for (int i = 0; i < map_length; i++) {
+            map[i] = new StackMapTableEntry(input, constant_pool);
+        }
+    }
+
+
+    /**
+     * Dump line number table attribute to file stream in binary format.
+     *
+     * @param file Output file stream
+     * @throws IOException
+     */
+    @Override
+    public final void dump( final DataOutputStream file ) throws IOException {
+        super.dump(file);
+        file.writeShort(map.length);
+        for (StackMapTableEntry entry : map) {
+            entry.dump(file);
+        }
+    }
+
+
+    /**
+     * @return Array of stack map entries
+     */
+    public final StackMapTableEntry[] getStackMapTable() {
+        return map;
+    }
+
+
+    /**
+     * @param map Array of stack map entries
+     */
+    public final void setStackMapTable( final StackMapTableEntry[] map ) {
+        this.map = map;
+        int len = 2; // Length of 'number_of_entries' field prior to the array of stack maps
+        for (StackMapTableEntry element : map) {
+            len += element.getMapEntrySize();
+        }
+        setLength(len);
+    }
+
+
+    /**
+     * @return String representation.
+     */
+    @Override
+    public final String toString() {
+        StringBuilder buf = new StringBuilder("StackMapTable(");
+        for (int i = 0; i < map.length; i++) {
+            buf.append(map[i]);
+            if (i < map.length - 1) {
+                buf.append(", ");
+            }
+        }
+        buf.append(')');
+        return buf.toString();
+    }
+
+
+    /**
+     * @return deep copy of this attribute
+     */
+    @Override
+    public Attribute copy( final ConstantPool _constant_pool ) {
+        StackMapTable c = (StackMapTable) clone();
+        c.map = new StackMapTableEntry[map.length];
+        for (int i = 0; i < map.length; i++) {
+            c.map[i] = map[i].copy();
+        }
+        c.setConstantPool(_constant_pool);
+        return c;
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitStackMapTable(this);
+    }
+
+
+    public final int getMapLength() {
+        return map == null ? 0 : map.length;
+    }
+}

--- a/src/main/java/org/apache/bcel/classfile/StackMapTableEntry.java
+++ b/src/main/java/org/apache/bcel/classfile/StackMapTableEntry.java
@@ -1,0 +1,427 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.bcel.classfile;
+
+import java.io.DataInput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import org.apache.bcel.Const;
+
+/**
+ * This class represents a stack map entry recording the types of
+ * local variables and the the of stack items at a given byte code offset.
+ * See CLDC specification �5.3.1.2
+ *
+ * @version $Id$
+ * @see     StackMapTable
+ * @see     StackMapType
+ */
+public final class StackMapTableEntry implements Node, Cloneable
+{
+
+    private int frame_type;
+    private int byte_code_offset;
+    private StackMapType[] types_of_locals;
+    private StackMapType[] types_of_stack_items;
+    private ConstantPool constant_pool;
+
+
+    /**
+     * Construct object from input stream.
+     * 
+     * @param input Input stream
+     * @throws IOException
+     */
+    StackMapTableEntry(final DataInput input, final ConstantPool constant_pool) throws IOException {
+        this(input.readByte() & 0xFF, -1, null, null, constant_pool);
+
+        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
+            byte_code_offset = frame_type - Const.SAME_FRAME;
+        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME && 
+                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            byte_code_offset = frame_type - Const.SAME_LOCALS_1_STACK_ITEM_FRAME;
+            types_of_stack_items = new StackMapType[1];
+            types_of_stack_items[0] = new StackMapType(input, constant_pool);
+        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            byte_code_offset = input.readShort();
+            types_of_stack_items = new StackMapType[1];
+            types_of_stack_items[0] = new StackMapType(input, constant_pool);
+        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
+            byte_code_offset = input.readShort();
+        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
+            byte_code_offset = input.readShort();
+        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
+            byte_code_offset = input.readShort();
+            int number_of_locals = frame_type - 251;
+            types_of_locals = new StackMapType[number_of_locals];
+            for (int i = 0; i < number_of_locals; i++) {
+                types_of_locals[i] = new StackMapType(input, constant_pool);
+            }            
+        } else if (frame_type == Const.FULL_FRAME) {        
+            byte_code_offset = input.readShort();
+            int number_of_locals = input.readShort();
+            types_of_locals = new StackMapType[number_of_locals];
+            for (int i = 0; i < number_of_locals; i++) {
+                types_of_locals[i] = new StackMapType(input, constant_pool);
+            }
+            int number_of_stack_items = input.readShort();
+            types_of_stack_items = new StackMapType[number_of_stack_items];
+            for (int i = 0; i < number_of_stack_items; i++) {
+                types_of_stack_items[i] = new StackMapType(input, constant_pool);
+            }
+        } else {
+            /* Can't happen */
+            throw new ClassFormatException ("Invalid frame type found while parsing stack map table: " + frame_type);
+        }
+    }
+
+    /**
+     * DO NOT USE
+     *
+     * @param byte_code_offset
+     * @param number_of_locals NOT USED
+     * @param types_of_locals array of {@link StackMapType}s of locals
+     * @param number_of_stack_items NOT USED
+     * @param types_of_stack_items array ot {@link StackMapType}s of stack items
+     * @param constant_pool the constant pool
+     * @deprecated Since 6.0, use {@link #StackMapTableEntry(int, int, StackMapType[], StackMapType[], ConstantPool)}
+     * instead
+     */
+    public StackMapTableEntry(final int byte_code_offset, final int number_of_locals,
+            final StackMapType[] types_of_locals, final int number_of_stack_items,
+            final StackMapType[] types_of_stack_items, final ConstantPool constant_pool) {
+        this.byte_code_offset = byte_code_offset;
+        this.types_of_locals = types_of_locals != null ? types_of_locals : new StackMapType[0];
+        this.types_of_stack_items = types_of_stack_items != null ? types_of_stack_items : new StackMapType[0];
+        this.constant_pool = constant_pool;
+    }
+
+    /**
+     * Create an instance
+     *
+     * @param tag the frame_type to use
+     * @param byte_code_offset
+     * @param types_of_locals array of {@link StackMapType}s of locals
+     * @param types_of_stack_items array ot {@link StackMapType}s of stack items
+     * @param constant_pool the constant pool
+     */
+    public StackMapTableEntry(final int tag, final int byte_code_offset,
+            final StackMapType[] types_of_locals,
+            final StackMapType[] types_of_stack_items, final ConstantPool constant_pool) {
+        this.frame_type = tag;
+        this.byte_code_offset = byte_code_offset;
+        this.types_of_locals = types_of_locals != null ? types_of_locals : new StackMapType[0];
+        this.types_of_stack_items = types_of_stack_items != null ? types_of_stack_items : new StackMapType[0];
+        this.constant_pool = constant_pool;
+    }
+
+
+    /**
+     * Dump stack map entry
+     *
+     * @param file Output file stream
+     * @throws IOException
+     */
+    public final void dump( final DataOutputStream file ) throws IOException {
+        file.write(frame_type);
+        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
+            // nothing to be done
+        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            types_of_stack_items[0].dump(file);
+        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            file.writeShort(byte_code_offset);
+            types_of_stack_items[0].dump(file);
+        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
+            file.writeShort(byte_code_offset);
+        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
+            file.writeShort(byte_code_offset);
+        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
+            file.writeShort(byte_code_offset);
+            for (StackMapType type : types_of_locals) {
+                type.dump(file);
+            }            
+        } else if (frame_type == Const.FULL_FRAME) {        
+            file.writeShort(byte_code_offset);
+            file.writeShort(types_of_locals.length);
+            for (StackMapType type : types_of_locals) {
+                type.dump(file);
+            }
+            file.writeShort(types_of_stack_items.length);
+            for (StackMapType type : types_of_stack_items) {
+                type.dump(file);
+            }
+        } else {
+            /* Can't happen */
+            throw new ClassFormatException ("Invalid Stack map table tag: " + frame_type);
+        }
+    }
+
+
+    /**
+     * @return String representation.
+     */
+    @Override
+    public final String toString() {
+        StringBuilder buf = new StringBuilder(64);
+        buf.append("(");
+        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
+            buf.append("SAME");
+        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                  frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            buf.append("SAME_LOCALS_1_STACK");
+        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            buf.append("SAME_LOCALS_1_STACK_EXTENDED");
+        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
+            buf.append("CHOP ").append(String.valueOf(251-frame_type));
+        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
+            buf.append("SAME_EXTENDED");
+        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
+            buf.append("APPEND ").append(String.valueOf(frame_type-251));
+        } else if (frame_type == Const.FULL_FRAME) {        
+            buf.append("FULL");
+        } else {
+            buf.append("UNKNOWN (").append(frame_type).append(")");
+        }
+        buf.append(", offset delta=").append(byte_code_offset);
+        if (types_of_locals.length > 0) {
+            buf.append(", locals={");
+            for (int i = 0; i < types_of_locals.length; i++) {
+                buf.append(types_of_locals[i]);
+                if (i < types_of_locals.length - 1) {
+                    buf.append(", ");
+                }
+            }
+            buf.append("}");
+        }
+        if (types_of_stack_items.length > 0) {
+            buf.append(", stack items={");
+            for (int i = 0; i < types_of_stack_items.length; i++) {
+                buf.append(types_of_stack_items[i]);
+                if (i < types_of_stack_items.length - 1) {
+                    buf.append(", ");
+                }
+            }
+            buf.append("}");
+        }
+        buf.append(")");
+        return buf.toString();
+    }
+
+
+    /**
+     * Calculate stack map entry size
+     *
+     */
+    int getMapEntrySize() {
+        if (frame_type >= Const.SAME_FRAME && frame_type <= Const.SAME_FRAME_MAX) {
+            return 1;
+        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME && 
+                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            return 1 + (types_of_stack_items[0].hasIndex() ? 3 : 1);
+        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) {
+            return 3 + (types_of_stack_items[0].hasIndex() ? 3 : 1);
+        } else if (frame_type >= Const.CHOP_FRAME && frame_type <= Const.CHOP_FRAME_MAX) {
+            return 3;
+        } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
+            return 3;
+        } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
+            int len = 3;
+            for (StackMapType types_of_local : types_of_locals) {
+                len += types_of_local.hasIndex() ? 3 : 1;
+            }            
+            return len;
+        } else if (frame_type == Const.FULL_FRAME) {        
+            int len = 7;
+            for (StackMapType types_of_local : types_of_locals) {
+                len += types_of_local.hasIndex() ? 3 : 1;
+            }
+            for (StackMapType types_of_stack_item : types_of_stack_items) {
+                len += types_of_stack_item.hasIndex() ? 3 : 1;
+            }
+            return len;
+        } else {
+            throw new RuntimeException("Invalid StackMapTable frame_type: " + frame_type);
+        }
+    }
+
+
+    public void setFrameType( final int f ) {
+        if (f >= Const.SAME_FRAME && f <= Const.SAME_FRAME_MAX) {
+            byte_code_offset = f - Const.SAME_FRAME;
+        } else if (f >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME && 
+                   f <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            byte_code_offset = f - Const.SAME_LOCALS_1_STACK_ITEM_FRAME;
+        } else if (f == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (f >= Const.CHOP_FRAME && f <= Const.CHOP_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (f == Const.SAME_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (f >= Const.APPEND_FRAME && f <= Const.APPEND_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (f == Const.FULL_FRAME) { // CHECKSTYLE IGNORE EmptyBlock
+        } else {
+            throw new RuntimeException("Invalid StackMapTable frame_type");
+        }
+        frame_type = f;
+    }
+
+
+    public int getFrameType() {
+        return frame_type;
+    }
+
+
+    public void setByteCodeOffset( final int new_offset ) {
+        if (new_offset < 0 || new_offset > 32767) {
+            throw new RuntimeException("Invalid StackMapTable offset: " + new_offset);
+        }
+
+        if (frame_type >= Const.SAME_FRAME &&
+            frame_type <= Const.SAME_FRAME_MAX) {
+            if (new_offset > Const.SAME_FRAME_MAX) {
+                frame_type = Const.SAME_FRAME_EXTENDED;
+            } else {
+                frame_type = new_offset;
+            }
+        } else if (frame_type >= Const.SAME_LOCALS_1_STACK_ITEM_FRAME &&
+                   frame_type <= Const.SAME_LOCALS_1_STACK_ITEM_FRAME_MAX) {
+            if (new_offset > Const.SAME_FRAME_MAX) {
+                frame_type = Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED;
+            } else {
+                frame_type = Const.SAME_LOCALS_1_STACK_ITEM_FRAME + new_offset;
+            }
+        } else if (frame_type == Const.SAME_LOCALS_1_STACK_ITEM_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frame_type >= Const.CHOP_FRAME &&
+                   frame_type <= Const.CHOP_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frame_type == Const.SAME_FRAME_EXTENDED) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frame_type >= Const.APPEND_FRAME &&
+                   frame_type <= Const.APPEND_FRAME_MAX) { // CHECKSTYLE IGNORE EmptyBlock
+        } else if (frame_type == Const.FULL_FRAME) { // CHECKSTYLE IGNORE EmptyBlock
+        } else {
+            throw new RuntimeException("Invalid StackMapTable frame_type: " + frame_type);
+        }
+        byte_code_offset = new_offset;
+    }
+
+
+    /**
+     * Update the distance (as an offset delta) from this StackMapTable
+     * entry to the next.  Note that this might cause the the
+     * frame type to change.  Note also that delta may be negative.
+     *
+     * @param int offset delta
+     */
+    public void updateByteCodeOffset(final int delta) {
+        setByteCodeOffset(byte_code_offset + delta);
+    }
+
+
+    public int getByteCodeOffset() {
+        return byte_code_offset;
+    }
+
+
+    @java.lang.Deprecated
+    public void setNumberOfLocals( final int n ) { // TODO unused
+    }
+
+
+    public int getNumberOfLocals() {
+        return types_of_locals.length;
+    }
+
+
+    public void setTypesOfLocals( final StackMapType[] types ) {
+        types_of_locals = types != null ? types : new StackMapType[0];
+    }
+
+
+    public StackMapType[] getTypesOfLocals() {
+        return types_of_locals;
+    }
+
+
+    @java.lang.Deprecated
+    public void setNumberOfStackItems( final int n ) { // TODO unused
+    }
+
+
+    public int getNumberOfStackItems() {
+        return types_of_stack_items.length;
+    }
+
+
+    public void setTypesOfStackItems( final StackMapType[] types ) {
+        types_of_stack_items = types != null ? types : new StackMapType[0];
+    }
+
+
+    public StackMapType[] getTypesOfStackItems() {
+        return types_of_stack_items;
+    }
+
+
+    /**
+     * @return deep copy of this object
+     */
+    public StackMapTableEntry copy() {
+        StackMapTableEntry e;
+        try {
+            e = (StackMapTableEntry) clone();
+        } catch (CloneNotSupportedException ex) {
+            throw new Error("Clone Not Supported");
+        }
+
+        e.types_of_locals = new StackMapType[types_of_locals.length];
+        for (int i = 0; i < types_of_locals.length; i++) {
+            e.types_of_locals[i] = types_of_locals[i].copy();
+        }
+        e.types_of_stack_items = new StackMapType[types_of_stack_items.length];
+        for (int i = 0; i < types_of_stack_items.length; i++) {
+            e.types_of_stack_items[i] = types_of_stack_items[i].copy();
+        }
+        return e;
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitely
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitStackMapTableEntry(this);
+    }
+
+
+    /**
+     * @return Constant pool used by this object.
+     */
+    public final ConstantPool getConstantPool() {
+        return constant_pool;
+    }
+
+
+    /**
+     * @param constant_pool Constant pool to be used for this object.
+     */
+    public final void setConstantPool( final ConstantPool constant_pool ) {
+        this.constant_pool = constant_pool;
+    }
+}

--- a/src/main/java/org/apache/bcel/classfile/StackMapType.java
+++ b/src/main/java/org/apache/bcel/classfile/StackMapType.java
@@ -25,11 +25,11 @@ import org.apache.bcel.Const;
 
 /**
  * This class represents the type of a local variable or item on stack
- * used in the StackMap entries.
+ * used in the StackMapTable entries.
  *
  * @version $Id$
- * @see     StackMapEntry
- * @see     StackMap
+ * @see     StackMapTableEntry
+ * @see     StackMapTable
  * @see     Const
  */
 public final class StackMapType implements Cloneable {

--- a/src/main/java/org/apache/bcel/classfile/Visitor.java
+++ b/src/main/java/org/apache/bcel/classfile/Visitor.java
@@ -95,6 +95,16 @@ public interface Visitor
     /**
      * @since 6.0
      */
+    void visitStackMapTable(StackMapTable obj);
+
+    /**
+     * @since 6.0
+     */
+    void visitStackMapTableEntry(StackMapTableEntry obj);
+
+    /**
+     * @since 6.0
+     */
     void visitAnnotation(Annotations obj);
 
     /**

--- a/src/main/java/org/apache/bcel/generic/MethodGen.java
+++ b/src/main/java/org/apache/bcel/generic/MethodGen.java
@@ -544,7 +544,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
     /**
      * Add an attribute to the code. Currently, the JVM knows about the
-     * LineNumberTable, LocalVariableTable and StackMap attributes,
+     * LineNumberTable, LocalVariableTable and StackMapTable attributes,
      * where the former two will be generated automatically and the
      * latter is used for the MIDP only. Other attributes will be
      * ignored by the JVM but do no harm.

--- a/src/main/java/org/apache/bcel/verifier/statics/StringRepresentation.java
+++ b/src/main/java/org/apache/bcel/verifier/statics/StringRepresentation.java
@@ -61,6 +61,8 @@ import org.apache.bcel.classfile.Signature;
 import org.apache.bcel.classfile.SourceFile;
 import org.apache.bcel.classfile.StackMap;
 import org.apache.bcel.classfile.StackMapEntry;
+import org.apache.bcel.classfile.StackMapTable;
+import org.apache.bcel.classfile.StackMapTableEntry;
 import org.apache.bcel.classfile.Synthetic;
 import org.apache.bcel.classfile.Unknown;
 import org.apache.bcel.verifier.exc.AssertionViolatedException;
@@ -304,6 +306,11 @@ public class StringRepresentation extends org.apache.bcel.classfile.EmptyVisitor
 
     @Override
     public void visitStackMap(final StackMap obj) {
+    	tostring = toString(obj);
+    }
+    
+    @Override
+    public void visitStackMapTable(final StackMapTable obj) {
         tostring = toString(obj);
     }
 
@@ -348,12 +355,17 @@ public class StringRepresentation extends org.apache.bcel.classfile.EmptyVisitor
     public void visitConstantInvokeDynamic(final ConstantInvokeDynamic obj) {
         tostring = toString(obj);
     }
+    
+    @Override
+    public void visitStackMapEntry(final StackMapEntry obj) {
+    	tostring = toString(obj);
+    }
 
     /**
      * @since 6.0
      */
     @Override
-    public void visitStackMapEntry(final StackMapEntry obj) {
+    public void visitStackMapTableEntry(final StackMapTableEntry obj) {
         tostring = toString(obj);
     }
     /**

--- a/src/test/java/org/apache/bcel/visitors/CounterVisitor.java
+++ b/src/test/java/org/apache/bcel/visitors/CounterVisitor.java
@@ -60,6 +60,8 @@ import org.apache.bcel.classfile.Signature;
 import org.apache.bcel.classfile.SourceFile;
 import org.apache.bcel.classfile.StackMap;
 import org.apache.bcel.classfile.StackMapEntry;
+import org.apache.bcel.classfile.StackMapTable;
+import org.apache.bcel.classfile.StackMapTableEntry;
 import org.apache.bcel.classfile.Synthetic;
 import org.apache.bcel.classfile.Unknown;
 import org.apache.bcel.classfile.Visitor;
@@ -72,8 +74,12 @@ public class CounterVisitor implements Visitor
     public int syntheticCount = 0;
 
     public int stackMapEntryCount = 0;
-
+    
     public int stackMapCount = 0;
+    
+    public int stackMapTableEntryCount = 0;
+
+    public int stackMapTableCount = 0;
 
     public int sourceFileCount = 0;
 
@@ -361,13 +367,25 @@ public class CounterVisitor implements Visitor
     @Override
     public void visitStackMap(final StackMap obj)
     {
-        stackMapCount++;
+    	stackMapCount++;
     }
-
+    
     @Override
     public void visitStackMapEntry(final StackMapEntry obj)
     {
-        stackMapEntryCount++;
+    	stackMapEntryCount++;
+    }
+
+    @Override
+    public void visitStackMapTable(final StackMapTable obj)
+    {
+        stackMapTableCount++;
+    }
+
+    @Override
+    public void visitStackMapTableEntry(final StackMapTableEntry obj)
+    {
+        stackMapTableEntryCount++;
     }
 
     @Override


### PR DESCRIPTION
First commit: added Git ignore file
Second commit: follow up on the BCEL6 compatibility discussion.

Attempt to fix the StackMapTable misery, see BCEL-92 and BCEL-248
Added StackMapTable/StackMapTableEntry back, basically 1:1 copy of
StackMap/StackMapEntry.
Added related, previously removed constants back to Constants (not they
match those from Const).
Updated Visitor* interfaces to handle both types.
Updated Attaribute to create StackMapTable in case we see
"StackMapTable" attribute.