### PR TITLE
BCEL-277: Resolve constant to a string representation occur NoSuchElementException in case CONSTANT_NameAndType constant.

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/ConstantPool.java
+++ b/src/main/java/org/apache/bcel/classfile/ConstantPool.java
@@ -131,7 +131,7 @@ public class ConstantPool implements Cloneable, Node {
             case Const.CONSTANT_NameAndType:
                 str = constantToString(((ConstantNameAndType) c).getNameIndex(),
                         Const.CONSTANT_Utf8)
-                        + ":" + constantToString(((ConstantNameAndType) c).getSignatureIndex(),
+                        + " " + constantToString(((ConstantNameAndType) c).getSignatureIndex(),
                         Const.CONSTANT_Utf8);
                 break;
             case Const.CONSTANT_InterfaceMethodref:
@@ -148,7 +148,7 @@ public class ConstantPool implements Cloneable, Node {
                 str = Const.getMethodHandleName(cmh.getReferenceKind())
                         + " " + constantToString(cmh.getReferenceIndex(),
                         getConstant(cmh.getReferenceIndex()).getTag());
-                break;            
+                break;
             case Const.CONSTANT_MethodType:
                 final ConstantMethodType cmt = (ConstantMethodType) c;
                 str = constantToString(cmt.getDescriptorIndex(), Const.CONSTANT_Utf8);
@@ -209,7 +209,7 @@ public class ConstantPool implements Cloneable, Node {
     }
 
 
-    /** 
+    /**
      * Dump constant pool to file stream in binary format.
      *
      * @param file Output file stream

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.bcel.classfile;
+
+import org.apache.bcel.AbstractTestCase;
+import org.apache.bcel.generic.ConstantPoolGen;
+import org.apache.bcel.generic.InstructionHandle;
+import org.apache.bcel.generic.InstructionList;
+import org.apache.bcel.generic.MethodGen;
+import org.junit.Test;
+
+/**
+ * @author sam
+ */
+public class ConstantPoolTestCase extends AbstractTestCase {
+    @Test
+    public void testConstantToString() throws ClassNotFoundException {
+        JavaClass clazz = getTestClass(PACKAGE_BASE_NAME + ".data.SimpleClassWithDefaultConstructor");
+        ConstantPoolGen cp = new ConstantPoolGen(clazz.getConstantPool());
+
+        Method[] methods = clazz.getMethods();
+
+        for (Method method : methods) {
+            if (method.getName().equals("<init>")) {
+                for (InstructionHandle instructionHandle : getInstructionHandles(clazz, cp, method)) {
+                    System.out.println(instructionHandle.getInstruction().toString(cp.getConstantPool()));
+                }
+            }
+        }
+    }
+
+    private InstructionHandle[] getInstructionHandles(JavaClass clazz, ConstantPoolGen cp, Method method) {
+        MethodGen methodGen = new MethodGen(method, clazz.getClassName(), cp);
+        InstructionList instructionList = methodGen.getInstructionList();
+        return instructionList.getInstructionHandles();
+    }
+}

--- a/src/test/java/org/apache/bcel/data/SimpleClassWithDefaultConstructor.java
+++ b/src/test/java/org/apache/bcel/data/SimpleClassWithDefaultConstructor.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+package org.apache.bcel.data;
+
+public class SimpleClassWithDefaultConstructor {
+    public SimpleClassWithDefaultConstructor() {
+    }
+
+    public static void main(final String[] argv) {
+        SimpleClassWithDefaultConstructor that = new SimpleClassWithDefaultConstructor();
+    }
+}


### PR DESCRIPTION
A method that constantToString of ConstantPool class always occur NoSuchElementException when face with costant type of CONSTANT_NameAndType.
A reason is invalid separator for StringTokenizer that colon. It should be replaced to empty string.
I had pull request include ConstantPoolTestCase.