### PR TITLE
BCEL-278: Resolving NoSuchElementException

### DIFF
--- a/src/main/java/org/apache/bcel/generic/InvokeInstruction.java
+++ b/src/main/java/org/apache/bcel/generic/InvokeInstruction.java
@@ -55,8 +55,19 @@ public abstract class InvokeInstruction extends FieldOrMethod implements Excepti
     public String toString( final ConstantPool cp ) {
         final Constant c = cp.getConstant(super.getIndex());
         final StringTokenizer tok = new StringTokenizer(cp.constantToString(c));
-        return Const.getOpcodeName(super.getOpcode()) + " " + tok.nextToken().replace('.', '/')
-                + tok.nextToken();
+
+        String opcodeName = Const.getOpcodeName(super.getOpcode());
+
+        StringBuilder sb = new StringBuilder(opcodeName);
+        if (tok.hasMoreTokens()) {
+            sb.append(" ");
+            sb.append(tok.nextToken().replace('.', '/'));
+            if (tok.hasMoreTokens()) {
+                sb.append(tok.nextToken());
+            }
+        }
+
+        return sb.toString();
     }
 
 


### PR DESCRIPTION
```
Exception in thread "main" java.util.NoSuchElementException
    at java.util.StringTokenizer.nextToken(StringTokenizer.java:349)
    at org.apache.bcel.generic.InvokeInstruction.toString(InvokeInstruction.java:58)
    at JasminVisitor.visitCode(JasminVisitor.java:268)
    at org.apache.bcel.classfile.Code.accept(Code.java:132)
    at org.apache.bcel.classfile.DescendingVisitor.visitCode(DescendingVisitor.java:179)
    at org.apache.bcel.classfile.Code.accept(Code.java:132)
    at org.apache.bcel.classfile.DescendingVisitor.visitMethod(DescendingVisitor.java:162)
    at org.apache.bcel.classfile.Method.accept(Method.java:108)
    at org.apache.bcel.classfile.DescendingVisitor.visitJavaClass(DescendingVisitor.java:99)
    at org.apache.bcel.classfile.JavaClass.accept(JavaClass.java:213)
    at org.apache.bcel.classfile.DescendingVisitor.visit(DescendingVisitor.java:85)
    at JasminVisitor.disassemble(JasminVisitor.java:77)
    at JasminVisitor.main(JasminVisitor.java:333)
```
