### PR TITLE
BCEL-289: iterate through parameter annotation entries using the right limit

### DIFF
--- a/src/main/java/org/apache/bcel/generic/MethodGen.java
+++ b/src/main/java/org/apache/bcel/generic/MethodGen.java
@@ -1146,11 +1146,11 @@ public class MethodGen extends FieldGenOrMethodGen {
                 } else {
                     paramAnnInvisAttr = rpa;
                 }
-                for (int j = 0; j < arg_types.length; j++)
+                final ParameterAnnotationEntry[] parameterAnnotationEntries = rpa.getParameterAnnotationEntries();
+                for (int j = 0; j < parameterAnnotationEntries.length; j++)
                 {
                     // This returns Annotation[] ...
-                    final ParameterAnnotationEntry immutableArray = rpa
-                            .getParameterAnnotationEntries()[j];
+                    final ParameterAnnotationEntry immutableArray = rpa.getParameterAnnotationEntries()[j];
                     // ... which needs transforming into an AnnotationGen[] ...
                     final List<AnnotationEntryGen> mutable = makeMutableVersion(immutableArray.getAnnotationEntries());
                     // ... then add these to any we already know about

--- a/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
@@ -18,6 +18,7 @@
 package org.apache.bcel.generic;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
@@ -32,6 +33,20 @@ public class MethodGenTestCase extends TestCase {
             @SuppressWarnings("unused")
             final
             int a = 1;
+        }
+    }
+
+    @interface A {        
+    }
+
+    @interface B {
+    }
+
+    public static class Bar {
+        public class Inner {
+            public Inner(@A Object a, @B Object b) {
+                
+            }
         }
     }
 
@@ -88,5 +103,15 @@ public class MethodGenTestCase extends TestCase {
         assertFalse("scope end still targeted by the removed variable", Arrays.asList(end.getTargeters()).contains(lv));
         assertNull("scope start", lv.getStart());
         assertNull("scope end", lv.getEnd());
+    }
+
+    public void testAnnotationsAreUnpacked() throws Exception {
+        final JavaClass jc = Repository.lookupClass(Bar.Inner.class);
+        final ClassGen cg = new ClassGen(jc);
+        final MethodGen mg = new MethodGen(cg.getMethodAt(0), cg.getClassName(), cg.getConstantPool());
+        final List<AnnotationEntryGen> firstParamAnnotations = mg.getAnnotationsOnParameter(0);
+        assertEquals("Wrong number of annotations in the first parameter", 1, firstParamAnnotations.size());
+        final List<AnnotationEntryGen> secondParamAnnotations = mg.getAnnotationsOnParameter(1);
+        assertEquals("Wrong number of annotations in the second parameter", 1, secondParamAnnotations.size());
     }
 }


### PR DESCRIPTION
The code was iterating through the number of parameters (3 in this case, the Bar parent class, and the two annotated parameters, while looking for annotated parameters.

As the constructor method has two annotated parameters, it throws an ArrayIndexOutOfBoundsException.

Found no pull requests with this fix, Maven site reports look OK, no new warnings/errors added, added a simple unit test.

As I never contributed to BCEL, will drop a message to the mailing list asking for someone to review it before I merge it.

Cheers
Bruno