### PR TITLE
[BCEL-304] Include Java 9+ modules in path used by ClassPath.java

### DIFF
--- a/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.bcel.util;
+
+import java.io.IOException;
+
+import org.apache.bcel.AbstractTestCase;
+
+public class ClassPathTestCase extends AbstractTestCase {
+
+    public void testGetClassFile() {
+        final String className = "java.lang.String";
+        try {
+            ClassPath.SYSTEM_CLASS_PATH.getClassFile(className);
+        } catch (IOException e) {
+            fail("Class file should have been found for: " + className);
+        }
+    }
+}


### PR DESCRIPTION
With the restructuring of Java .class files in Java 9 and higher to be in modules instead of the rt.jar, the ClassPath.getClassFile method would fail to find Java class files (ex: String.class). These modifications include the Java 9+ modules in the path used by ClassPath.java so that the .class files can be located.