### PR TITLE
Fix spotbugs

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/LineNumberTable.java
+++ b/src/main/java/org/apache/bcel/classfile/LineNumberTable.java
@@ -165,7 +165,7 @@ public final class LineNumberTable extends Attribute {
         /* Do a binary search since the array is ordered.
          */
         do {
-            final int i = (l + r) / 2;
+            final int i = (l + r) >>> 1;
             final int j = line_number_table[i].getStartPC();
             if (j == pos) {
                 return line_number_table[i].getLineNumber();

--- a/src/main/java/org/apache/bcel/generic/InstructionList.java
+++ b/src/main/java/org/apache/bcel/generic/InstructionList.java
@@ -113,7 +113,7 @@ public class InstructionList implements Iterable<InstructionHandle> {
          * Do a binary search since the pos array is orderd.
          */
         do {
-            final int i = (l + r) / 2;
+            final int i = (l + r) >>> 1;
             final int j = pos[i];
             if (j == target) {
                 return ihs[i];

--- a/src/main/java/org/apache/bcel/generic/SWITCH.java
+++ b/src/main/java/org/apache/bcel/generic/SWITCH.java
@@ -102,7 +102,7 @@ public final class SWITCH implements CompoundInstruction {
         int i = l;
         int j = r;
         int h;
-        final int m = match[(l + r) / 2];
+        final int m = match[(l + r) >>> 1];
         InstructionHandle h2;
         do {
             while (match[i] < m) {

--- a/src/main/java/org/apache/bcel/util/ModularRuntimeImage.java
+++ b/src/main/java/org/apache/bcel/util/ModularRuntimeImage.java
@@ -83,12 +83,10 @@ public class ModularRuntimeImage implements Closeable {
     @Override
     public void close() throws IOException {
         if (classLoader != null) {
-            if (classLoader != null) {
-                classLoader.close();
-            }
-            if (fileSystem != null) {
-                fileSystem.close();
-            }
+            classLoader.close();
+        }
+        if (fileSystem != null) {
+            fileSystem.close();
         }
     }
 


### PR DESCRIPTION
Fixes the SpotBugs issues found during review of release 6.3.1.

Checkstyle also noted 2 whitespace errors but when I run a trailing whitespace fix on the code it actually finds 36 files. So I'll not submit those to make this PR nice and simple.