### PR TITLE
[BCEL-321] AbstractClassPathRepository to share findClass logic for repositories

### DIFF
--- a/src/main/java/org/apache/bcel/util/AbstractClassPathRepository.java
+++ b/src/main/java/org/apache/bcel/util/AbstractClassPathRepository.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.bcel.util;
+
+import org.apache.bcel.classfile.ClassParser;
+import org.apache.bcel.classfile.JavaClass;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This abstract class provides a logic of a loading {@link JavaClass} objects class names via {@link ClassPath}.
+ *
+ * <p>Subclasses can choose caching strategy of the objects by implementing the abstract methods (e.g., {@link
+ * #storeClass(JavaClass)} and {@link #findClass(String)}).
+ *
+ * @since 6.4.0
+ */
+abstract class AbstractClassPathRepository implements Repository {
+
+    private final ClassPath _path;
+
+    AbstractClassPathRepository(final ClassPath classPath) {
+        _path = classPath;
+    }
+
+    @Override
+    public abstract void storeClass(final JavaClass javaClass);
+
+    @Override
+    public abstract void removeClass(final JavaClass javaClass);
+
+    @Override
+    public abstract JavaClass findClass(final String className);
+
+    @Override
+    public abstract void clear();
+
+    /**
+     * Finds a JavaClass object by name. If it is already in this Repository, the Repository version is returned.
+     * Otherwise, the Repository's classpath is searched for the class (and it is added to the Repository if found).
+     *
+     * @param className
+     *            the name of the class
+     * @return the JavaClass object
+     * @throws ClassNotFoundException
+     *             if the class is not in the Repository, and could not be found on the classpath
+     */
+    @Override
+    public JavaClass loadClass(String className) throws ClassNotFoundException {
+        if ((className == null) || className.isEmpty()) {
+            throw new IllegalArgumentException("Invalid class name " + className);
+        }
+        className = className.replace('/', '.'); // Just in case, canonical form
+        final JavaClass clazz = findClass(className);
+        if (clazz != null) {
+            return clazz;
+        }
+        try {
+            return loadClass(_path.getInputStream(className), className);
+        } catch (final IOException e) {
+            throw new ClassNotFoundException("Exception while looking for class " + className + ": " + e, e);
+        }
+    }
+
+    /**
+     * Finds the JavaClass object for a runtime Class object. If a class with the same name is already in this
+     * Repository, the Repository version is returned. Otherwise, getResourceAsStream() is called on the Class object to
+     * find the class's representation. If the representation is found, it is added to the Repository.
+     *
+     * @see Class
+     * @param clazz the runtime Class object
+     * @return JavaClass object for given runtime class
+     * @throws ClassNotFoundException
+     *             if the class is not in the Repository, and its representation could not be found
+     */
+    @Override
+    public JavaClass loadClass(final Class<?> clazz) throws ClassNotFoundException {
+        final String className = clazz.getName();
+        final JavaClass repositoryClass = findClass(className);
+        if (repositoryClass != null) {
+            return repositoryClass;
+        }
+        String name = className;
+        final int i = name.lastIndexOf('.');
+        if (i > 0) {
+            name = name.substring(i + 1);
+        }
+        JavaClass cls = null;
+        try (InputStream clsStream = clazz.getResourceAsStream(name + ".class")) {
+            return cls = loadClass(clsStream, className);
+        } catch (final IOException e) {
+            return cls;
+        }
+    }
+
+    private JavaClass loadClass(final InputStream inputStream, final String className) throws ClassNotFoundException {
+        try {
+            if (inputStream != null) {
+                final ClassParser parser = new ClassParser(inputStream, className);
+                final JavaClass clazz = parser.parse();
+                storeClass(clazz);
+                return clazz;
+            }
+        } catch (final IOException e) {
+            throw new ClassNotFoundException("Exception while looking for class " + className + ": " + e, e);
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (final IOException e) {
+                    // ignored
+                }
+            }
+        }
+        throw new ClassNotFoundException("SyntheticRepository could not load " + className);
+    }
+
+    @Override
+    public ClassPath getClassPath() {
+        return _path;
+    }
+}

--- a/src/main/java/org/apache/bcel/util/AbstractClassPathRepository.java
+++ b/src/main/java/org/apache/bcel/util/AbstractClassPathRepository.java
@@ -27,7 +27,7 @@ import java.io.InputStream;
  * This abstract class provides a logic of a loading {@link JavaClass} objects class names via {@link ClassPath}.
  *
  * <p>Subclasses can choose caching strategy of the objects by implementing the abstract methods (e.g., {@link
- * #storeClass(JavaClass)} and {@link #findClass(String)}).
+ * #storeClass(JavaClass)} and {@link #findClass(String)}).</p>
  *
  * @since 6.4.0
  */
@@ -63,7 +63,7 @@ abstract class AbstractClassPathRepository implements Repository {
      */
     @Override
     public JavaClass loadClass(String className) throws ClassNotFoundException {
-        if ((className == null) || className.isEmpty()) {
+        if (className == null || className.isEmpty()) {
             throw new IllegalArgumentException("Invalid class name " + className);
         }
         className = className.replace('/', '.'); // Just in case, canonical form
@@ -101,11 +101,11 @@ abstract class AbstractClassPathRepository implements Repository {
         if (i > 0) {
             name = name.substring(i + 1);
         }
-        JavaClass cls = null;
+
         try (InputStream clsStream = clazz.getResourceAsStream(name + ".class")) {
-            return cls = loadClass(clsStream, className);
+            return loadClass(clsStream, className);
         } catch (final IOException e) {
-            return cls;
+            return null;
         }
     }
 

--- a/src/main/java/org/apache/bcel/util/AbstractClassPathRepository.java
+++ b/src/main/java/org/apache/bcel/util/AbstractClassPathRepository.java
@@ -128,7 +128,7 @@ abstract class AbstractClassPathRepository implements Repository {
                 }
             }
         }
-        throw new ClassNotFoundException("SyntheticRepository could not load " + className);
+        throw new ClassNotFoundException("ClassRepository could not load " + className);
     }
 
     @Override

--- a/src/main/java/org/apache/bcel/util/ClassPathRepository.java
+++ b/src/main/java/org/apache/bcel/util/ClassPathRepository.java
@@ -17,12 +17,9 @@
  */
 package org.apache.bcel.util;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.JavaClass;
 
 /**
@@ -31,13 +28,12 @@ import org.apache.bcel.classfile.JavaClass;
  *
  * @see org.apache.bcel.Repository
  */
-public class ClassPathRepository implements Repository {
+public class ClassPathRepository extends AbstractClassPathRepository {
 
-    private ClassPath _path = null;
     private final Map<String, JavaClass> _loadedClasses = new HashMap<>(); // CLASSNAME X JAVACLASS
 
     public ClassPathRepository(final ClassPath classPath) {
-        _path = classPath;
+        super(classPath);
     }
 
     /**
@@ -50,7 +46,7 @@ public class ClassPathRepository implements Repository {
     }
 
     /**
-     * Removes class from repository
+     * Removes class from repository.
      */
     @Override
     public void removeClass(final JavaClass javaClass) {
@@ -63,95 +59,6 @@ public class ClassPathRepository implements Repository {
     @Override
     public JavaClass findClass(final String className) {
         return _loadedClasses.get(className);
-    }
-
-    /**
-     * Finds a JavaClass object by name. If it is already in this Repository, the Repository version is returned. Otherwise, the Repository's classpath is
-     * searched for the class (and it is added to the Repository if found).
-     *
-     * @param className
-     *            the name of the class
-     * @return the JavaClass object
-     * @throws ClassNotFoundException
-     *             if the class is not in the Repository, and could not be found on the classpath
-     */
-    @Override
-    public JavaClass loadClass(String className) throws ClassNotFoundException {
-        if ((className == null) || className.isEmpty()) {
-            throw new IllegalArgumentException("Invalid class name " + className);
-        }
-        className = className.replace('/', '.'); // Just in case, canonical form
-        final JavaClass clazz = findClass(className);
-        if (clazz != null) {
-            return clazz;
-        }
-        try {
-            return loadClass(_path.getInputStream(className), className);
-        } catch (final IOException e) {
-            throw new ClassNotFoundException("Exception while looking for class " + className + ": " + e, e);
-        }
-    }
-
-    /**
-     * Finds the JavaClass object for a runtime Class object. If a class with the same name is already in this Repository, the Repository version is returned.
-     * Otherwise, getResourceAsStream() is called on the Class object to find the class's representation. If the representation is found, it is added to the
-     * Repository.
-     *
-     * @see Class
-     * @param clazz
-     *            the runtime Class object
-     * @return JavaClass object for given runtime class
-     * @throws ClassNotFoundException
-     *             if the class is not in the Repository, and its representation could not be found
-     */
-    @Override
-    public JavaClass loadClass(final Class<?> clazz) throws ClassNotFoundException {
-        final String className = clazz.getName();
-        final JavaClass repositoryClass = findClass(className);
-        if (repositoryClass != null) {
-            return repositoryClass;
-        }
-        String name = className;
-        final int i = name.lastIndexOf('.');
-        if (i > 0) {
-            name = name.substring(i + 1);
-        }
-        JavaClass cls = null;
-        try (InputStream clsStream = clazz.getResourceAsStream(name + ".class")) {
-            return cls = loadClass(clsStream, className);
-        } catch (final IOException e) {
-            return cls;
-        }
-    }
-
-    private JavaClass loadClass(final InputStream inputStream, final String className) throws ClassNotFoundException {
-        try {
-            if (inputStream != null) {
-                final ClassParser parser = new ClassParser(inputStream, className);
-                final JavaClass clazz = parser.parse();
-                storeClass(clazz);
-                return clazz;
-            }
-        } catch (final IOException e) {
-            throw new ClassNotFoundException("Exception while looking for class " + className + ": " + e, e);
-        } finally {
-            if (inputStream != null) {
-                try {
-                    inputStream.close();
-                } catch (final IOException e) {
-                    // ignored
-                }
-            }
-        }
-        throw new ClassNotFoundException("SyntheticRepository could not load " + className);
-    }
-
-    /**
-     * ClassPath associated with the Repository.
-     */
-    @Override
-    public ClassPath getClassPath() {
-        return _path;
     }
 
     /**

--- a/src/main/java/org/apache/bcel/util/LruCacheClassPathRepository.java
+++ b/src/main/java/org/apache/bcel/util/LruCacheClassPathRepository.java
@@ -32,7 +32,7 @@ import org.apache.bcel.classfile.JavaClass;
  * 
  * @since 6.4.0
  */
-public class LruCacheClassPathRepository extends ClassPathRepository {
+public class LruCacheClassPathRepository extends AbstractClassPathRepository {
 
     private final LinkedHashMap<String, JavaClass> loadedClasses;
 
@@ -65,5 +65,15 @@ public class LruCacheClassPathRepository extends ClassPathRepository {
         // Not storing parent's _loadedClass
         loadedClasses.put(javaClass.getClassName(), javaClass);
         javaClass.setRepository(this);
+    }
+
+    @Override
+    public void removeClass(final JavaClass javaClass) {
+        loadedClasses.remove(javaClass.getClassName());
+    }
+
+    @Override
+    public void clear() {
+        loadedClasses.clear();
     }
 }

--- a/src/main/java/org/apache/bcel/util/MemorySensitiveClassPathRepository.java
+++ b/src/main/java/org/apache/bcel/util/MemorySensitiveClassPathRepository.java
@@ -17,13 +17,10 @@
  */
 package org.apache.bcel.util;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.ref.SoftReference;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.JavaClass;
 
 /**
@@ -33,13 +30,12 @@ import org.apache.bcel.classfile.JavaClass;
  *
  * @see org.apache.bcel.Repository
  */
-public class MemorySensitiveClassPathRepository implements Repository {
+public class MemorySensitiveClassPathRepository extends AbstractClassPathRepository {
 
-    private ClassPath _path = null;
     private final Map<String, SoftReference<JavaClass>> _loadedClasses = new HashMap<>(); // CLASSNAME X JAVACLASS
 
     public MemorySensitiveClassPathRepository(final ClassPath path) {
-        this._path = path;
+        super(path);
     }
 
     /**
@@ -47,6 +43,7 @@ public class MemorySensitiveClassPathRepository implements Repository {
      */
     @Override
     public void storeClass(final JavaClass clazz) {
+        // Not calling super.storeClass because this subclass maintains the mapping.
         _loadedClasses.put(clazz.getClassName(), new SoftReference<>(clazz));
         clazz.setRepository(this);
     }
@@ -69,96 +66,6 @@ public class MemorySensitiveClassPathRepository implements Repository {
             return null;
         }
         return ref.get();
-    }
-
-    /**
-     * Find a JavaClass object by name. If it is already in this Repository, the Repository version is returned. Otherwise, the Repository's classpath is
-     * searched for the class (and it is added to the Repository if found).
-     *
-     * @param className
-     *            the name of the class
-     * @return the JavaClass object
-     * @throws ClassNotFoundException
-     *             if the class is not in the Repository, and could not be found on the classpath
-     */
-    @Override
-    public JavaClass loadClass(String className) throws ClassNotFoundException {
-        if ((className == null) || className.isEmpty()) {
-            throw new IllegalArgumentException("Invalid class name " + className);
-        }
-        className = className.replace('/', '.'); // Just in case, canonical form
-        final JavaClass clazz = findClass(className);
-        if (clazz != null) {
-            return clazz;
-        }
-        try {
-            return loadClass(_path.getInputStream(className), className);
-        } catch (final IOException e) {
-            throw new ClassNotFoundException("Exception while looking for class " + className + ": " + e, e);
-        }
-    }
-
-    /**
-     * Find the JavaClass object for a runtime Class object. If a class with the same name is already in this Repository, the Repository version is returned.
-     * Otherwise, getResourceAsStream() is called on the Class object to find the class's representation. If the representation is found, it is added to the
-     * Repository.
-     *
-     * @see Class
-     * @param clazz
-     *            the runtime Class object
-     * @return JavaClass object for given runtime class
-     * @throws ClassNotFoundException
-     *             if the class is not in the Repository, and its representation could not be found
-     */
-    @Override
-    public JavaClass loadClass(final Class<?> clazz) throws ClassNotFoundException {
-        final String className = clazz.getName();
-        final JavaClass repositoryClass = findClass(className);
-        if (repositoryClass != null) {
-            return repositoryClass;
-        }
-        String name = className;
-        final int i = name.lastIndexOf('.');
-        if (i > 0) {
-            name = name.substring(i + 1);
-        }
-        JavaClass cls = null;
-        try (InputStream clsStream = clazz.getResourceAsStream(name + ".class")) {
-            return cls = loadClass(clsStream, className);
-        } catch (final IOException e) {
-            return cls;
-        }
-
-    }
-
-    private JavaClass loadClass(final InputStream is, final String className) throws ClassNotFoundException {
-        try {
-            if (is != null) {
-                final ClassParser parser = new ClassParser(is, className);
-                final JavaClass clazz = parser.parse();
-                storeClass(clazz);
-                return clazz;
-            }
-        } catch (final IOException e) {
-            throw new ClassNotFoundException("Exception while looking for class " + className + ": " + e, e);
-        } finally {
-            if (is != null) {
-                try {
-                    is.close();
-                } catch (final IOException e) {
-                    // ignored
-                }
-            }
-        }
-        throw new ClassNotFoundException("SyntheticRepository could not load " + className);
-    }
-
-    /**
-     * ClassPath associated with the Repository.
-     */
-    @Override
-    public ClassPath getClassPath() {
-        return _path;
     }
 
     /**

--- a/src/test/java/org/apache/bcel/BCELBenchmark.java
+++ b/src/test/java/org/apache/bcel/BCELBenchmark.java
@@ -15,112 +15,112 @@
  * limitations under the License.
  */
 
-//package org.apache.bcel;
-//
-//import java.io.ByteArrayInputStream;
-//import java.io.IOException;
-//import java.util.concurrent.TimeUnit;
-//import java.util.jar.JarEntry;
-//import java.util.jar.JarFile;
-//
-//import org.apache.bcel.classfile.ClassParser;
-//import org.apache.bcel.classfile.JavaClass;
-//import org.apache.bcel.classfile.Method;
-//import org.apache.bcel.generic.ClassGen;
-//import org.apache.bcel.generic.InstructionList;
-//import org.apache.bcel.generic.MethodGen;
-//import org.apache.commons.collections4.Predicate;
-//import org.apache.commons.collections4.iterators.EnumerationIterator;
-//import org.apache.commons.collections4.iterators.FilterIterator;
-//import org.apache.commons.collections4.iterators.IteratorIterable;
-//import org.apache.commons.io.IOUtils;
-//import org.openjdk.jmh.annotations.Benchmark;
-//import org.openjdk.jmh.annotations.BenchmarkMode;
-//import org.openjdk.jmh.annotations.Fork;
-//import org.openjdk.jmh.annotations.Measurement;
-//import org.openjdk.jmh.annotations.Mode;
-//import org.openjdk.jmh.annotations.OutputTimeUnit;
-//import org.openjdk.jmh.annotations.Threads;
-//import org.openjdk.jmh.annotations.Warmup;
-//import org.openjdk.jmh.infra.Blackhole;
-//
-//@BenchmarkMode(Mode.AverageTime)
-//@Fork(value = 1, jvmArgs = "-server")
-//@Threads(1)
-//@Warmup(iterations = 10)
-//@Measurement(iterations = 20)
-//@OutputTimeUnit(TimeUnit.MILLISECONDS)
-//public class BCELBenchmark {
-//
-//    private JarFile getJarFile() throws IOException {
-//        String javaHome = System.getProperty("java.home");
-//        return new JarFile(javaHome + "/lib/rt.jar");
-//    }
-//
-//    private Iterable<JarEntry> getClasses(JarFile jar) {
-//        return new IteratorIterable<>(new FilterIterator<>(new EnumerationIterator<>(jar.entries()), new Predicate<JarEntry>() {
-//            @Override
-//            public boolean evaluate(JarEntry entry) {
-//                return entry.getName().endsWith(".class");
-//            }
-//        }));
-//    }
-//
-//    /**
-//     * Baseline benchmark. Read the classes but don't parse them.
-//     */
-//    @Benchmark
-//    public void baseline(Blackhole bh) throws IOException {
-//        JarFile jar = getJarFile();
-//
-//        for (JarEntry entry : getClasses(jar)) {
-//            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
-//            bh.consume(bytes);
-//        }
-//
-//        jar.close();
-//    }
-//
-//    @Benchmark
-//    public void parser(Blackhole bh) throws IOException {
-//        JarFile jar = getJarFile();
-//
-//        for (JarEntry entry : getClasses(jar)) {
-//            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
-//
-//            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
-//            bh.consume(clazz);
-//        }
-//
-//        jar.close();
-//    }
-//
-//    @Benchmark
-//    public void generator(Blackhole bh) throws IOException {
-//        JarFile jar = getJarFile();
-//
-//        for (JarEntry entry : getClasses(jar)) {
-//            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
-//
-//            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
-//
-//            ClassGen cg = new ClassGen(clazz);
-//
-//            for (Method m : cg.getMethods()) {
-//                MethodGen mg = new MethodGen(m, cg.getClassName(), cg.getConstantPool());
-//                InstructionList il = mg.getInstructionList();
-//
-//                if (il != null) {
-//                    mg.getInstructionList().setPositions();
-//                    mg.setMaxLocals();
-//                    mg.setMaxStack();
-//                }
-//                cg.replaceMethod(m, mg.getMethod());
-//            }
-//
-//            bh.consume(cg.getJavaClass().getBytes());
-//        }
-//
-//        jar.close();
-//    }
-//}
+package org.apache.bcel;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import org.apache.bcel.classfile.ClassParser;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.ClassGen;
+import org.apache.bcel.generic.InstructionList;
+import org.apache.bcel.generic.MethodGen;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.iterators.EnumerationIterator;
+import org.apache.commons.collections4.iterators.FilterIterator;
+import org.apache.commons.collections4.iterators.IteratorIterable;
+import org.apache.commons.io.IOUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, jvmArgs = "-server")
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 20)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class BCELBenchmark {
+
+    private JarFile getJarFile() throws IOException {
+        String javaHome = System.getProperty("java.home");
+        return new JarFile(javaHome + "/lib/rt.jar");
+    }
+
+    private Iterable<JarEntry> getClasses(JarFile jar) {
+        return new IteratorIterable<>(new FilterIterator<>(new EnumerationIterator<>(jar.entries()), new Predicate<JarEntry>() {
+            @Override
+            public boolean evaluate(JarEntry entry) {
+                return entry.getName().endsWith(".class");
+            }
+        }));
+    }
+
+    /**
+     * Baseline benchmark. Read the classes but don't parse them.
+     */
+    @Benchmark
+    public void baseline(Blackhole bh) throws IOException {
+        JarFile jar = getJarFile();
+
+        for (JarEntry entry : getClasses(jar)) {
+            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
+            bh.consume(bytes);
+        }
+
+        jar.close();
+    }
+
+    @Benchmark
+    public void parser(Blackhole bh) throws IOException {
+        JarFile jar = getJarFile();
+
+        for (JarEntry entry : getClasses(jar)) {
+            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
+
+            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
+            bh.consume(clazz);
+        }
+
+        jar.close();
+    }
+
+    @Benchmark
+    public void generator(Blackhole bh) throws IOException {
+        JarFile jar = getJarFile();
+
+        for (JarEntry entry : getClasses(jar)) {
+            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
+
+            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
+
+            ClassGen cg = new ClassGen(clazz);
+
+            for (Method m : cg.getMethods()) {
+                MethodGen mg = new MethodGen(m, cg.getClassName(), cg.getConstantPool());
+                InstructionList il = mg.getInstructionList();
+
+                if (il != null) {
+                    mg.getInstructionList().setPositions();
+                    mg.setMaxLocals();
+                    mg.setMaxStack();
+                }
+                cg.replaceMethod(m, mg.getMethod());
+            }
+
+            bh.consume(cg.getJavaClass().getBytes());
+        }
+
+        jar.close();
+    }
+}

--- a/src/test/java/org/apache/bcel/BCELBenchmark.java
+++ b/src/test/java/org/apache/bcel/BCELBenchmark.java
@@ -15,112 +15,112 @@
  * limitations under the License.
  */
 
-package org.apache.bcel;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-
-import org.apache.bcel.classfile.ClassParser;
-import org.apache.bcel.classfile.JavaClass;
-import org.apache.bcel.classfile.Method;
-import org.apache.bcel.generic.ClassGen;
-import org.apache.bcel.generic.InstructionList;
-import org.apache.bcel.generic.MethodGen;
-import org.apache.commons.collections4.Predicate;
-import org.apache.commons.collections4.iterators.EnumerationIterator;
-import org.apache.commons.collections4.iterators.FilterIterator;
-import org.apache.commons.collections4.iterators.IteratorIterable;
-import org.apache.commons.io.IOUtils;
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Threads;
-import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
-
-@BenchmarkMode(Mode.AverageTime)
-@Fork(value = 1, jvmArgs = "-server")
-@Threads(1)
-@Warmup(iterations = 10)
-@Measurement(iterations = 20)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
-public class BCELBenchmark {
-
-    private JarFile getJarFile() throws IOException {
-        String javaHome = System.getProperty("java.home");
-        return new JarFile(javaHome + "/lib/rt.jar");
-    }
-
-    private Iterable<JarEntry> getClasses(JarFile jar) {
-        return new IteratorIterable<>(new FilterIterator<>(new EnumerationIterator<>(jar.entries()), new Predicate<JarEntry>() {
-            @Override
-            public boolean evaluate(JarEntry entry) {
-                return entry.getName().endsWith(".class");
-            }
-        }));
-    }
-
-    /**
-     * Baseline benchmark. Read the classes but don't parse them.
-     */
-    @Benchmark
-    public void baseline(Blackhole bh) throws IOException {
-        JarFile jar = getJarFile();
-
-        for (JarEntry entry : getClasses(jar)) {
-            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
-            bh.consume(bytes);
-        }
-
-        jar.close();
-    }
-
-    @Benchmark
-    public void parser(Blackhole bh) throws IOException {
-        JarFile jar = getJarFile();
-
-        for (JarEntry entry : getClasses(jar)) {
-            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
-
-            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
-            bh.consume(clazz);
-        }
-
-        jar.close();
-    }
-
-    @Benchmark
-    public void generator(Blackhole bh) throws IOException {
-        JarFile jar = getJarFile();
-
-        for (JarEntry entry : getClasses(jar)) {
-            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
-
-            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
-
-            ClassGen cg = new ClassGen(clazz);
-
-            for (Method m : cg.getMethods()) {
-                MethodGen mg = new MethodGen(m, cg.getClassName(), cg.getConstantPool());
-                InstructionList il = mg.getInstructionList();
-
-                if (il != null) {
-                    mg.getInstructionList().setPositions();
-                    mg.setMaxLocals();
-                    mg.setMaxStack();
-                }
-                cg.replaceMethod(m, mg.getMethod());
-            }
-
-            bh.consume(cg.getJavaClass().getBytes());
-        }
-
-        jar.close();
-    }
-}
+//package org.apache.bcel;
+//
+//import java.io.ByteArrayInputStream;
+//import java.io.IOException;
+//import java.util.concurrent.TimeUnit;
+//import java.util.jar.JarEntry;
+//import java.util.jar.JarFile;
+//
+//import org.apache.bcel.classfile.ClassParser;
+//import org.apache.bcel.classfile.JavaClass;
+//import org.apache.bcel.classfile.Method;
+//import org.apache.bcel.generic.ClassGen;
+//import org.apache.bcel.generic.InstructionList;
+//import org.apache.bcel.generic.MethodGen;
+//import org.apache.commons.collections4.Predicate;
+//import org.apache.commons.collections4.iterators.EnumerationIterator;
+//import org.apache.commons.collections4.iterators.FilterIterator;
+//import org.apache.commons.collections4.iterators.IteratorIterable;
+//import org.apache.commons.io.IOUtils;
+//import org.openjdk.jmh.annotations.Benchmark;
+//import org.openjdk.jmh.annotations.BenchmarkMode;
+//import org.openjdk.jmh.annotations.Fork;
+//import org.openjdk.jmh.annotations.Measurement;
+//import org.openjdk.jmh.annotations.Mode;
+//import org.openjdk.jmh.annotations.OutputTimeUnit;
+//import org.openjdk.jmh.annotations.Threads;
+//import org.openjdk.jmh.annotations.Warmup;
+//import org.openjdk.jmh.infra.Blackhole;
+//
+//@BenchmarkMode(Mode.AverageTime)
+//@Fork(value = 1, jvmArgs = "-server")
+//@Threads(1)
+//@Warmup(iterations = 10)
+//@Measurement(iterations = 20)
+//@OutputTimeUnit(TimeUnit.MILLISECONDS)
+//public class BCELBenchmark {
+//
+//    private JarFile getJarFile() throws IOException {
+//        String javaHome = System.getProperty("java.home");
+//        return new JarFile(javaHome + "/lib/rt.jar");
+//    }
+//
+//    private Iterable<JarEntry> getClasses(JarFile jar) {
+//        return new IteratorIterable<>(new FilterIterator<>(new EnumerationIterator<>(jar.entries()), new Predicate<JarEntry>() {
+//            @Override
+//            public boolean evaluate(JarEntry entry) {
+//                return entry.getName().endsWith(".class");
+//            }
+//        }));
+//    }
+//
+//    /**
+//     * Baseline benchmark. Read the classes but don't parse them.
+//     */
+//    @Benchmark
+//    public void baseline(Blackhole bh) throws IOException {
+//        JarFile jar = getJarFile();
+//
+//        for (JarEntry entry : getClasses(jar)) {
+//            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
+//            bh.consume(bytes);
+//        }
+//
+//        jar.close();
+//    }
+//
+//    @Benchmark
+//    public void parser(Blackhole bh) throws IOException {
+//        JarFile jar = getJarFile();
+//
+//        for (JarEntry entry : getClasses(jar)) {
+//            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
+//
+//            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
+//            bh.consume(clazz);
+//        }
+//
+//        jar.close();
+//    }
+//
+//    @Benchmark
+//    public void generator(Blackhole bh) throws IOException {
+//        JarFile jar = getJarFile();
+//
+//        for (JarEntry entry : getClasses(jar)) {
+//            byte[] bytes = IOUtils.toByteArray(jar.getInputStream(entry));
+//
+//            JavaClass clazz = new ClassParser(new ByteArrayInputStream(bytes), entry.getName()).parse();
+//
+//            ClassGen cg = new ClassGen(clazz);
+//
+//            for (Method m : cg.getMethods()) {
+//                MethodGen mg = new MethodGen(m, cg.getClassName(), cg.getConstantPool());
+//                InstructionList il = mg.getInstructionList();
+//
+//                if (il != null) {
+//                    mg.getInstructionList().setPositions();
+//                    mg.setMaxLocals();
+//                    mg.setMaxStack();
+//                }
+//                cg.replaceMethod(m, mg.getMethod());
+//            }
+//
+//            bh.consume(cg.getJavaClass().getBytes());
+//        }
+//
+//        jar.close();
+//    }
+//}

--- a/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.bcel.util;
+
+import java.io.IOException;
+
+import org.apache.bcel.classfile.JavaClass;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Tests {@link ClassPathRepository} and {@link MemorySensitiveClassPathRepository}.
+ */
+public class ClassPathRepositoryTestCase {
+
+    private void verifyCaching(AbstractClassPathRepository repository) throws ClassNotFoundException {
+        JavaClass class1 = repository.loadClass("java.lang.String");
+        Assert.assertNotNull(class1);
+        JavaClass class2 = repository.loadClass("java.lang.Long");
+        Assert.assertNotNull(class2);
+
+        Assert.assertEquals(class1, repository.findClass("java.lang.String"));
+        Assert.assertEquals(class2, repository.findClass("java.lang.Long"));
+    }
+
+    @Test
+    public void testClassPathRepository() throws ClassNotFoundException, IOException {
+        try (final ClassPath classPath = new ClassPath("")) {
+            verifyCaching(new ClassPathRepository(classPath));
+        }
+    }
+
+    @Test
+    public void testMemorySensitiveClassPathRepository() throws ClassNotFoundException, IOException {
+        try (final ClassPath classPath = new ClassPath("")) {
+            verifyCaching(new ClassPathRepository(classPath));
+        }
+    }
+}

--- a/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
@@ -49,7 +49,7 @@ public class ClassPathRepositoryTestCase {
     @Test
     public void testMemorySensitiveClassPathRepository() throws ClassNotFoundException, IOException {
         try (final ClassPath classPath = new ClassPath("")) {
-            verifyCaching(new ClassPathRepository(classPath));
+            verifyCaching(new MemorySensitiveClassPathRepository(classPath));
         }
     }
 }

--- a/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
@@ -31,13 +31,23 @@ import org.junit.Test;
 public class ClassPathRepositoryTestCase {
 
     private void verifyCaching(AbstractClassPathRepository repository) throws ClassNotFoundException {
+        // Tests loadClass()
         JavaClass class1 = repository.loadClass("java.lang.String");
         Assert.assertNotNull(class1);
         JavaClass class2 = repository.loadClass("java.lang.Long");
         Assert.assertNotNull(class2);
 
+        // Tests findClass()
         Assert.assertEquals(class1, repository.findClass("java.lang.String"));
         Assert.assertEquals(class2, repository.findClass("java.lang.Long"));
+
+        // Tests removeClass()
+        repository.removeClass(class1);
+        Assert.assertNull(repository.findClass("java.lang.String"));
+
+        // Tests clear()
+        repository.clear();
+        Assert.assertNull(repository.findClass("java.lang.Long"));
     }
 
     @Test

--- a/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
@@ -23,9 +23,10 @@ import org.apache.bcel.classfile.JavaClass;
 import org.junit.Assert;
 import org.junit.Test;
 
-
 /**
  * Tests {@link ClassPathRepository} and {@link MemorySensitiveClassPathRepository}.
+ *
+ * <p>Without memory scarcity, these two classes behave in the same manner.
  */
 public class ClassPathRepositoryTestCase {
 


### PR DESCRIPTION
# Problem to solve
BCEL has different Repository classes with slight modification in its underlying cache:

- ClassPathRepository uses HashMap<String, JavaClass> for JavaClass cache
- MemorySensitiveClassPathRepository uses HashMap<String, SoftReference<JavaClass>
- New LruCacheClassPathRepository by BCEL-320 will use LinkedHashMap<String, JavaClass> for JavaClass cache

The logic of loadClass, storeClass, and findClass methods are almost same ([attached screenshot in BCEL-321](https://issues.apache.org/jira/browse/BCEL-321)). I think they can leverage an abstraction over the internal cache so that they will have less duplicate code.

# Solution

This PR introduces AbstractClassPathRepository to share findClass logic for these repositories. The subclasses focus on how to cache the result via storeClass and findClass methods.


# jacoco report

## Coverage

![image](https://user-images.githubusercontent.com/28604/60915241-572f0880-a259-11e9-87d8-15e5f6fd95ca.png)

## No incompatible changes
![image](https://user-images.githubusercontent.com/28604/60912607-bee25500-a253-11e9-8b6a-4101acff2cfc.png)
