### PR TITLE
[BCEL-323]BCELifier to set major and minor versions

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -73,6 +73,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="BCEL-322" type="add" dev="ggregory" due-to="Gary Gregory">Add constants to org.apache.bcel.Const for Java 14.</action>
       <action issue="BCEL-270" type="fix" dev="ggregory" due-to="Alexandru-Constantin Bledea">Calling toString(ConstantPool) on InvokeInstruction throws NullPointerException.</action>
       <action issue="BCEL-321" type="add" dev="ggregory" due-to="Tomo Suzuki">Refactor subclasses of ClassPathRepository for differences in underlying cache.</action>
+      <action issue="BCEL-323" type="fix" dev="ggregory" due-to="Tomo Suzuki">org.apache.bcel.util.BCELifier to set major and minor versions.</action>
     </release>
 
     <release version="6.3.1" date="2019-03-20" description="Bug fix release">

--- a/src/main/java/org/apache/bcel/util/BCELifier.java
+++ b/src/main/java/org/apache/bcel/util/BCELifier.java
@@ -108,6 +108,8 @@ public class BCELifier extends org.apache.bcel.classfile.EmptyVisitor {
                 + "\", \"" + super_name + "\", " + "\"" + clazz.getSourceFileName() + "\", "
                 + printFlags(clazz.getAccessFlags(), FLAGS.CLASS) + ", "
                 + "new String[] { " + inter + " });");
+        _out.println("    _cg.setMajor(" + clazz.getMajor() +");");
+        _out.println("    _cg.setMinor(" + clazz.getMinor() +");");
         _out.println();
         _out.println("    _cp = _cg.getConstantPool();");
         _out.println("    _factory = new InstructionFactory(_cg, _cp);");


### PR DESCRIPTION
The continuous integration builds have been failing for JDK 13 ([build history](https://travis-ci.org/apache/commons-bcel/builds)).

- The failing test was comparing the output of javap command. JDK 13's javap outputs "default" if major.minor >= 52.0  ([OpenJDK's commit in June 2019](http://hg.openjdk.java.net/jdk/jdk13/rev/77b54b2822cc))
- BCELifer was not copying major minor (default 45.3).

See [BCEL-323](https://issues.apache.org/jira/browse/BCEL-323) for details.

Now the build succeeds:

![image](https://user-images.githubusercontent.com/28604/60995321-4bf2e000-a320-11e9-9137-08e2c10ee7c3.png)
