### PR TITLE
Made some variable names more consistent with the other parts.

### DIFF
--- a/src/main/java/org/apache/bcel/Const.java
+++ b/src/main/java/org/apache/bcel/Const.java
@@ -2010,12 +2010,12 @@ public final class Const {
 
   /**
    *
-   * @param index
+   * @param opcode
    * @return Number of byte code operands
    * @since 6.0
    */
-  public static short getNoOfOperands(final int index) {
-      return NO_OF_OPERANDS[index];
+  public static short getNoOfOperands(final int opcode) {
+      return NO_OF_OPERANDS[opcode];
   }
 
   /**
@@ -2162,8 +2162,8 @@ public final class Const {
   /**
    * @since 6.0
    */
-  public static String getOpcodeName(final int index) {
-      return OPCODE_NAMES[index];
+  public static String getOpcodeName(final int opcode) {
+      return OPCODE_NAMES[opcode];
   }
 
   /**

--- a/src/main/java/org/apache/bcel/classfile/AccessFlags.java
+++ b/src/main/java/org/apache/bcel/classfile/AccessFlags.java
@@ -35,11 +35,11 @@ public abstract class AccessFlags {
     }
 
     /**
-     * @param a
+     * @param flags
      *            inital access flags
      */
-    public AccessFlags(final int a) {
-        access_flags = a;
+    public AccessFlags(final int flags) {
+        access_flags = flags;
     }
 
     /**

--- a/src/main/java/org/apache/bcel/classfile/ClassFormatException.java
+++ b/src/main/java/org/apache/bcel/classfile/ClassFormatException.java
@@ -32,8 +32,8 @@ public class ClassFormatException extends RuntimeException {
     }
 
 
-    public ClassFormatException(final String s) {
-        super(s);
+    public ClassFormatException(final String message) {
+        super(message);
     }
 
     /**

--- a/src/main/java/org/apache/bcel/classfile/Code.java
+++ b/src/main/java/org/apache/bcel/classfile/Code.java
@@ -242,13 +242,13 @@ public final class Code extends Attribute {
      * including the size of all its contained attributes
      */
     private int calculateLength() {
-        int len = 0;
+        int length = 0;
         if (attributes != null) {
             for (final Attribute attribute : attributes) {
-                len += attribute.getLength() + 6 /*attribute header size*/;
+                length += attribute.getLength() + 6 /*attribute header size*/;
             }
         }
-        return len + getInternalLength();
+        return length + getInternalLength();
     }
 
 

--- a/src/main/java/org/apache/bcel/classfile/ConstantPool.java
+++ b/src/main/java/org/apache/bcel/classfile/ConstantPool.java
@@ -171,10 +171,10 @@ public class ConstantPool implements Cloneable, Node {
     }
 
     private static String escape( final String str ) {
-        final int len = str.length();
-        final StringBuilder buf = new StringBuilder(len + 5);
+        final int length = str.length();
+        final StringBuilder buf = new StringBuilder(length + 5);
         final char[] ch = str.toCharArray();
-        for (int i = 0; i < len; i++) {
+        for (int i = 0; i < length; i++) {
             switch (ch[i]) {
                 case '\n':
                     buf.append("\\n");

--- a/src/main/java/org/apache/bcel/classfile/EnclosingMethod.java
+++ b/src/main/java/org/apache/bcel/classfile/EnclosingMethod.java
@@ -45,12 +45,12 @@ public class EnclosingMethod extends Attribute {
     private int methodIndex;
 
     // Ctors - and code to read an attribute in.
-    EnclosingMethod(final int nameIndex, final int len, final DataInput input, final ConstantPool cpool) throws IOException {
-        this(nameIndex, len, input.readUnsignedShort(), input.readUnsignedShort(), cpool);
+    EnclosingMethod(final int nameIndex, final int length, final DataInput input, final ConstantPool cpool) throws IOException {
+        this(nameIndex, length, input.readUnsignedShort(), input.readUnsignedShort(), cpool);
     }
 
-    private EnclosingMethod(final int nameIndex, final int len, final int classIdx,final int methodIdx, final ConstantPool cpool) {
-        super(Const.ATTR_ENCLOSING_METHOD, nameIndex, len, cpool);
+    private EnclosingMethod(final int nameIndex, final int length, final int classIdx,final int methodIdx, final ConstantPool cpool) {
+        super(Const.ATTR_ENCLOSING_METHOD, nameIndex, length, cpool);
         classIndex  = classIdx;
         methodIndex = methodIdx;
     }

--- a/src/main/java/org/apache/bcel/classfile/LocalVariableTypeTable.java
+++ b/src/main/java/org/apache/bcel/classfile/LocalVariableTypeTable.java
@@ -67,8 +67,8 @@ public class LocalVariableTypeTable extends Attribute {
         this.local_variable_type_table = local_variable_table;
     }
 
-    LocalVariableTypeTable(final int nameIdx, final int len, final DataInput input, final ConstantPool cpool) throws IOException {
-        this(nameIdx, len, (LocalVariable[]) null, cpool);
+    LocalVariableTypeTable(final int name_index, final int length, final DataInput input, final ConstantPool cpool) throws IOException {
+        this(name_index, length, (LocalVariable[]) null, cpool);
 
         final int local_variable_type_table_length = input.readUnsignedShort();
         local_variable_type_table = new LocalVariable[local_variable_type_table_length];

--- a/src/main/java/org/apache/bcel/classfile/StackMap.java
+++ b/src/main/java/org/apache/bcel/classfile/StackMap.java
@@ -101,11 +101,11 @@ public final class StackMap extends Attribute {
      */
     public void setStackMap( final StackMapEntry[] map ) {
         this.map = map;
-        int len = 2; // Length of 'number_of_entries' field prior to the array of stack maps
+        int length = 2; // Length of 'number_of_entries' field prior to the array of stack maps
         for (final StackMapEntry element : map) {
-            len += element.getMapEntrySize();
+            length += element.getMapEntrySize();
         }
-        setLength(len);
+        setLength(length);
     }
 
 

--- a/src/main/java/org/apache/bcel/classfile/StackMapEntry.java
+++ b/src/main/java/org/apache/bcel/classfile/StackMapEntry.java
@@ -241,20 +241,20 @@ public final class StackMapEntry implements Node, Cloneable
         } else if (frame_type == Const.SAME_FRAME_EXTENDED) {
             return 3;
         } else if (frame_type >= Const.APPEND_FRAME && frame_type <= Const.APPEND_FRAME_MAX) {
-            int len = 3;
+            int length = 3;
             for (final StackMapType types_of_local : types_of_locals) {
-                len += types_of_local.hasIndex() ? 3 : 1;
+                length += types_of_local.hasIndex() ? 3 : 1;
             }
-            return len;
+            return length;
         } else if (frame_type == Const.FULL_FRAME) {
-            int len = 7;
+            int length = 7;
             for (final StackMapType types_of_local : types_of_locals) {
-                len += types_of_local.hasIndex() ? 3 : 1;
+                length += types_of_local.hasIndex() ? 3 : 1;
             }
             for (final StackMapType types_of_stack_item : types_of_stack_items) {
-                len += types_of_stack_item.hasIndex() ? 3 : 1;
+                length += types_of_stack_item.hasIndex() ? 3 : 1;
             }
-            return len;
+            return length;
         } else {
             throw new RuntimeException("Invalid StackMap frame_type: " + frame_type);
         }

--- a/src/main/java/org/apache/bcel/classfile/Utility.java
+++ b/src/main/java/org/apache/bcel/classfile/Utility.java
@@ -492,12 +492,12 @@ public abstract class Utility {
      * @return Compacted class name
      */
     public static String compactClassName( String str, final String prefix, final boolean chopit ) {
-        final int len = prefix.length();
+        final int length = prefix.length();
         str = str.replace('/', '.'); // Is `/' on all systems, even DOS
         if (chopit) {
             // If string starts with `prefix' and contains no further dots
-            if (str.startsWith(prefix) && (str.substring(len).indexOf('.') == -1)) {
-                str = str.substring(len);
+            if (str.startsWith(prefix) && (str.substring(length).indexOf('.') == -1)) {
+                str = str.substring(length);
             }
         }
         return str;
@@ -1565,11 +1565,11 @@ public abstract class Utility {
 
 
         @Override
-        public int read( final char[] cbuf, final int off, final int len ) throws IOException {
-            for (int i = 0; i < len; i++) {
+        public int read( final char[] cbuf, final int off, final int length ) throws IOException {
+            for (int i = 0; i < length; i++) {
                 cbuf[off + i] = (char) read();
             }
-            return len;
+            return length;
         }
     }
 
@@ -1608,16 +1608,16 @@ public abstract class Utility {
 
 
         @Override
-        public void write( final char[] cbuf, final int off, final int len ) throws IOException {
-            for (int i = 0; i < len; i++) {
+        public void write( final char[] cbuf, final int off, final int length ) throws IOException {
+            for (int i = 0; i < length; i++) {
                 write(cbuf[off + i]);
             }
         }
 
 
         @Override
-        public void write( final String str, final int off, final int len ) throws IOException {
-            write(str.toCharArray(), off, len);
+        public void write( final String str, final int off, final int length ) throws IOException {
+            write(str.toCharArray(), off, length);
         }
     }
 

--- a/src/main/java/org/apache/bcel/generic/InstructionConst.java
+++ b/src/main/java/org/apache/bcel/generic/InstructionConst.java
@@ -287,10 +287,10 @@ public final class InstructionConst {
 
     /**
      * Gets the Instruction.
-     * @param index the index, e.g. {@link Const#RETURN}
+     * @param opcode the index, e.g. {@link Const#RETURN}
      * @return the entry from the private INSTRUCTIONS table
      */
-    public static Instruction getInstruction(final int index) {
-        return INSTRUCTIONS[index];
+    public static Instruction getInstruction(final int opcode) {
+        return INSTRUCTIONS[opcode];
     }
 }

--- a/src/main/java/org/apache/bcel/util/ClassPath.java
+++ b/src/main/java/org/apache/bcel/util/ClassPath.java
@@ -173,8 +173,8 @@ public class ClassPath implements Closeable {
 
         private final String dir;
 
-        Dir(final String d) {
-            dir = d;
+        Dir(final String path) {
+            dir = path;
         }
 
         @Override
@@ -487,8 +487,8 @@ public class ClassPath implements Closeable {
         getPathComponents(bootClassPathProp, list);
         final List<String> dirs = new ArrayList<>();
         getPathComponents(extDirs, dirs);
-        for (final String d : dirs) {
-            final File ext_dir = new File(d);
+        for (final String path : dirs) {
+            final File ext_dir = new File(path);
             final String[] extensions = ext_dir.list(ARCHIVE_FILTER);
             if (extensions != null) {
                 for (final String extension : extensions) {

--- a/src/main/java/org/apache/bcel/util/InstructionFinder.java
+++ b/src/main/java/org/apache/bcel/util/InstructionFinder.java
@@ -89,11 +89,11 @@ public class InstructionFinder {
      * match.
      */
     public final void reread() {
-        final int size = il.getLength();
-        final char[] buf = new char[size]; // Create a string with length equal to il length
+        final int length = il.getLength();
+        final char[] buf = new char[length]; // Create a string with length equal to il length
         handles = il.getInstructionHandles();
         // Map opcodes to characters
-        for (int i = 0; i < size; i++) {
+        for (int i = 0; i < length; i++) {
             buf[i] = makeChar(handles[i].getInstruction().getOpcode());
         }
         il_string = new String(buf);
@@ -134,14 +134,14 @@ public class InstructionFinder {
         //Bug: BCEL-77 - Instructions are assumed to be english, to avoid odd Locale issues
         final String lower = pattern.toLowerCase(Locale.ENGLISH);
         final StringBuilder buf = new StringBuilder();
-        final int size = pattern.length();
-        for (int i = 0; i < size; i++) {
+        final int length = pattern.length();
+        for (int i = 0; i < length; i++) {
             char ch = lower.charAt(i);
             if (Character.isLetterOrDigit(ch)) {
                 final StringBuilder name = new StringBuilder();
-                while ((Character.isLetterOrDigit(ch) || ch == '_') && i < size) {
+                while ((Character.isLetterOrDigit(ch) || ch == '_') && i < length) {
                     name.append(ch);
-                    if (++i < size) {
+                    if (++i < length) {
                         ch = lower.charAt(i);
                     } else {
                         break;

--- a/src/main/java/org/apache/bcel/verifier/structurals/Subroutines.java
+++ b/src/main/java/org/apache/bcel/verifier/structurals/Subroutines.java
@@ -121,16 +121,16 @@ public class Subroutines{
             ret.append("', Instructions: '").append(instructions).append("'.");
 
             ret.append(" Accessed local variable slots: '");
-            int[] alv = getAccessedLocalsIndices();
-            for (final int element : alv) {
-                ret.append(element);ret.append(" ");
+            int[] lvs = getAccessedLocalsIndices();
+            for (final int lv : lvs) {
+                ret.append(lv);ret.append(" ");
             }
             ret.append("'.");
 
             ret.append(" Recursively (via subsub...routines) accessed local variable slots: '");
-            alv = getRecursivelyAccessedLocalsIndices();
-            for (final int element : alv) {
-                ret.append(element);ret.append(" ");
+            lvs = getRecursivelyAccessedLocalsIndices();
+            for (final int lv : lvs) {
+                ret.append(lv);ret.append(" ");
             }
             ret.append("'.");
 


### PR DESCRIPTION
Hello, we're developing an automated system that detects inconsistent variable names in a large software project. Our system checks if each variable name is consistent with other variables in the project in its usage pattern, and proposes correct candidates if inconsistency is detected. This is a part of academic research that we hope to publish soon, but as a part of the evaluation, we applied our systems to your projects and got a few interesting results. We carefully reviewed our system output and manually created a patch to correct a few variable names. We would be delighted if this patch is found to be useful. If you have a question or suggestion regarding this patch, we'd happily
answer. Thank you.

P.S. our patch is purely for readability purposes and does not change any functionality. A couple of issues that we've noticed were left untouched. For example, the use of variable names "len" and "length" were fairly widespread, but we have only corrected a few notable instances to minimize our impact.