### PR TITLE
Javadoc fix for BCEL-335

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/Code.java
+++ b/src/main/java/org/apache/bcel/classfile/Code.java
@@ -312,6 +312,7 @@ public final class Code extends Attribute {
         if (attributes.length > 0) {
             buf.append("\nAttribute(s) = ");
             for (final Attribute attribute : attributes) {
+                buf.append("\n").append(attribute.getName()).append(":");
                 buf.append("\n").append(attribute);
             }
         }

--- a/src/main/java/org/apache/bcel/classfile/Code.java
+++ b/src/main/java/org/apache/bcel/classfile/Code.java
@@ -312,7 +312,6 @@ public final class Code extends Attribute {
         if (attributes.length > 0) {
             buf.append("\nAttribute(s) = ");
             for (final Attribute attribute : attributes) {
-                buf.append("\n").append(attribute.getName()).append(":");
                 buf.append("\n").append(attribute);
             }
         }

--- a/src/main/java/org/apache/bcel/util/package.html
+++ b/src/main/java/org/apache/bcel/util/package.html
@@ -24,7 +24,6 @@ This package contains utility classes for the
 <a href="https://commons.apache.org/bcel/">Byte Code Engineering
 Library</a>, namely:
 </p>
-<p>
 <ul>
 <li>Collection classes for JavaClass objects</li>
 <li>A converter for class files to HTML</li>
@@ -33,6 +32,5 @@ Library</a>, namely:
 <li>A class loader that allows to create classes at run time</li>
 </ul>
 
-</p>
 </body>
 </html>


### PR DESCRIPTION
newer versions of javadoc are more stringent

https://issues.apache.org/jira/browse/BCEL-335