### PR TITLE
PLSE 6.4.1.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ jdk:
   - openjdk-ea
 
 after_success:
-  - mvn -Ddoclint:none clean cobertura:cobertura coveralls:report
+  - mvn -Drat.skip=true -Ddoclint:none clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ jdk:
   - openjdk-ea
 
 after_success:
-  - mvn -Drat.skip=true -Ddoclint:none clean cobertura:cobertura coveralls:report
+  - mvn -Ddoclint:none clean cobertura:cobertura coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,7 @@
             <exclude>**/*.bnf</exclude>
             <exclude>**/*.mini</exclude>
             <exclude>TODO.JustIce</exclude>
+            <exclude>README-codespecs.txt</exclude>
             <exclude>src/examples/Mini/MiniParser$JJCalls</exclude>
           </excludes>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.apache.bcel</groupId>
   <artifactId>bcel</artifactId>
   <packaging>jar</packaging>
-  <version>6.4.2-SNAPSHOT</version>
+  <version>6.4.1.1</version>
   <name>Apache Commons BCEL</name>
   <description>Apache Commons Bytecode Engineering Library</description>
 
@@ -47,7 +47,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons.componentid>bcel</commons.componentid>
     <commons.module.name>org.apache.bcel</commons.module.name>
-    <commons.release.version>6.4.2</commons.release.version>
+    <commons.release.version>6.4.1.1</commons.release.version>
     <commons.release.isDistModule>true</commons.release.isDistModule>
     <commons.rc.version>RC1</commons.rc.version>
     <commons.bc.version>6.4.1</commons.bc.version>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,7 +62,11 @@ The <action> type attribute can be add,update,fix,remove.
    -->
 
   <body>
-    <release version="6.4.2" date="2019-MM-DD" description="Bug fix release.">
+    <release version="6.4.1.1" date="2020-02-24" description="University of Washington PLSE Bug fix release.">
+      <action                  type="update" due-to="Mark Roberts">Allow clients to manipulate Annotations.</action>
+      <action issue="BCEL-335" type="fix" due-to="Mark Roberts">fix jdk 11 javadoc error.</action>
+      <action issue="BCEL-334" type="update" due-to="Mark Roberts">Add attribute name headings to toString of a Code attribute.</action>
+      <action issue="BCEL-333" type="fix" due-to="Mark Roberts">InovokeStatic may refer to either a MethodRef or an InterfaceMethodRef.</action>
       <action issue="BCEL-330" type="update" dev="ggregory" due-to="Mark Roberts">Remove unnecessary references to Constants.</action>
       <action issue="BCEL-329" type="fix" dev="ggregory" due-to="Gary Gregory, Mark Roberts">MethodGen duplicates some attributes.</action>
       <action                  type="update" dev="ggregory" due-to="Gary Gregory">Update tests from JNA 5.4.0 to 5.5.0.</action>

--- a/src/main/java/org/apache/bcel/classfile/Code.java
+++ b/src/main/java/org/apache/bcel/classfile/Code.java
@@ -312,6 +312,7 @@ public final class Code extends Attribute {
         if (attributes.length > 0) {
             buf.append("\nAttribute(s) = ");
             for (final Attribute attribute : attributes) {
+                buf.append("\n").append(attribute.getName()).append(":");
                 buf.append("\n").append(attribute);
             }
         }

--- a/src/main/java/org/apache/bcel/generic/FieldGenOrMethodGen.java
+++ b/src/main/java/org/apache/bcel/generic/FieldGenOrMethodGen.java
@@ -120,7 +120,7 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
     /**
      * @since 6.0
      */
-    protected void addAnnotationEntry(final AnnotationEntryGen ag) // TODO could this be package protected?
+    public void addAnnotationEntry(final AnnotationEntryGen ag) // TODO could this be package protected?
     {
         annotation_vec.add(ag);
     }
@@ -136,7 +136,7 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
     /**
      * @since 6.0
      */
-    protected void removeAnnotationEntry(final AnnotationEntryGen ag) // TODO could this be package protected?
+    public void removeAnnotationEntry(final AnnotationEntryGen ag) // TODO could this be package protected?
     {
         annotation_vec.remove(ag);
     }
@@ -152,7 +152,7 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
     /**
      * @since 6.0
      */
-    protected void removeAnnotationEntries() // TODO could this be package protected?
+    public void removeAnnotationEntries() // TODO could this be package protected?
     {
         annotation_vec.clear();
     }

--- a/src/main/java/org/apache/bcel/generic/InstructionFactory.java
+++ b/src/main/java/org/apache/bcel/generic/InstructionFactory.java
@@ -83,13 +83,28 @@ public class InstructionFactory implements InstructionConstants {
      */
     public InvokeInstruction createInvoke( final String class_name, final String name, final Type ret_type,
             final Type[] arg_types, final short kind ) {
+        return createInvoke(class_name, name, ret_type, arg_types, kind, kind == Const.INVOKEINTERFACE);
+    }
+
+    /** Create an invoke instruction. (Except for invokedynamic.)
+     *
+     * @param class_name name of the called class
+     * @param name name of the called method
+     * @param ret_type return type of method
+     * @param arg_types argument types of method
+     * @param kind how to invoke: INVOKEINTERFACE, INVOKESTATIC, INVOKEVIRTUAL, or INVOKESPECIAL
+     * @param use_interface force use of InterfaceMethodref
+     * @since 6.4.2
+     */
+    public InvokeInstruction createInvoke( final String class_name, final String name, final Type ret_type,
+            final Type[] arg_types, final short kind, final boolean use_interface ) {
         int index;
         int nargs = 0;
         final String signature = Type.getMethodSignature(ret_type, arg_types);
         for (final Type arg_type : arg_types) {
             nargs += arg_type.getSize();
         }
-        if (kind == Const.INVOKEINTERFACE) {
+        if (use_interface) {
             index = cp.addInterfaceMethodref(class_name, name, signature);
         } else {
             index = cp.addMethodref(class_name, name, signature);

--- a/src/main/java/org/apache/bcel/util/package.html
+++ b/src/main/java/org/apache/bcel/util/package.html
@@ -24,7 +24,6 @@ This package contains utility classes for the
 <a href="https://commons.apache.org/bcel/">Byte Code Engineering
 Library</a>, namely:
 </p>
-<p>
 <ul>
 <li>Collection classes for JavaClass objects</li>
 <li>A converter for class files to HTML</li>
@@ -33,6 +32,5 @@ Library</a>, namely:
 <li>A class loader that allows to create classes at run time</li>
 </ul>
 
-</p>
 </body>
 </html>


### PR DESCRIPTION
This pull request identifies this as PLSE commons-bcel release 6.4.1.1. The last official Apache release is 6.4.1. This version has three changes to support Daikon on jdk11:

src/main/java/org/apache/bcel/generic/MethodGen.java to improve Attribute support
src/main/java/org/apache/bcel/generic/InstructionFactory.java to add support for static interfaces
src/main/java/org/apache/bcel/generic/FieldGenOrMethodGen.java to improve Annotation support
It also contains two minor changes:

src/main/java/org/apache/bcel/classfile/Code.java to improve the toString() output.
src/main/java/org/apache/bcel/util/package.html to fix HTML for JDK 11