### PR TITLE
BCEL-341: Oak class file patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,11 @@
     <contributor>
       <name>Sam Yoon</name>
     </contributor>
+
+    <contributor>
+      <name>Hippo</name>
+      <email>hippah at protonmail.com</email>
+    </contributor>
   </contributors>
 
   <mailingLists>

--- a/src/main/java/org/apache/bcel/classfile/Attribute.java
+++ b/src/main/java/org/apache/bcel/classfile/Attribute.java
@@ -86,6 +86,7 @@ public abstract class Attribute implements Cloneable, Node {
         }
     }
 
+
     /**
      * Class method reads one attribute from the input data stream. This method
      * must not be accessible from the outside. It is called by the Field and
@@ -102,6 +103,28 @@ public abstract class Attribute implements Cloneable, Node {
      * @since 6.0
      */
     public static Attribute readAttribute(final DataInput file, final ConstantPool constant_pool)
+            throws IOException, ClassFormatException
+    {
+        return readAttribute(file, constant_pool, false);
+    }
+
+    /**
+     * Class method reads one attribute from the input data stream. This method
+     * must not be accessible from the outside. It is called by the Field and
+     * Method constructor methods.
+     *
+     * @see Field
+     * @see Method
+     *
+     * @param file Input stream
+     * @param constant_pool Array of constants
+     * @param isOak If the the class file is oak
+     * @return Attribute
+     * @throws IOException
+     * @throws ClassFormatException
+     * @since 6.0
+     */
+    public static Attribute readAttribute(final DataInput file, final ConstantPool constant_pool, final boolean isOak)
             throws IOException, ClassFormatException
     {
         byte tag = Const.ATTR_UNKNOWN; // Unknown attribute
@@ -138,7 +161,7 @@ public abstract class Attribute implements Cloneable, Node {
             case Const.ATTR_SOURCE_FILE:
                 return new SourceFile(name_index, length, file, constant_pool);
             case Const.ATTR_CODE:
-                return new Code(name_index, length, file, constant_pool);
+                return new Code(name_index, length, file, constant_pool, isOak);
             case Const.ATTR_EXCEPTIONS:
                 return new ExceptionTable(name_index, length, file, constant_pool);
             case Const.ATTR_LINE_NUMBER_TABLE:

--- a/src/main/java/org/apache/bcel/classfile/ClassParser.java
+++ b/src/main/java/org/apache/bcel/classfile/ClassParser.java
@@ -58,6 +58,7 @@ public final class ClassParser {
     private Attribute[] attributes; // attributes defined in the class
     private final boolean isZip; // Loaded from zip file
     private static final int BUFSIZE = 8192;
+    private boolean isOak; // Is oak class file
 
 
     /**
@@ -290,7 +291,7 @@ public final class ClassParser {
         final int methods_count = dataInputStream.readUnsignedShort();
         methods = new Method[methods_count];
         for (int i = 0; i < methods_count; i++) {
-            methods[i] = new Method(dataInputStream, constantPool);
+            methods[i] = new Method(dataInputStream, constantPool, isOak);
         }
     }
 
@@ -303,5 +304,6 @@ public final class ClassParser {
     private void readVersion() throws IOException, ClassFormatException {
         minor = dataInputStream.readUnsignedShort();
         major = dataInputStream.readUnsignedShort();
+        isOak = major < Const.MAJOR_1_1 || (major == Const.MAJOR_1_1 && minor < 3);
     }
 }

--- a/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
+++ b/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
@@ -100,12 +100,23 @@ public abstract class FieldOrMethod extends AccessFlags implements Cloneable, No
      * @throws ClassFormatException
      */
     protected FieldOrMethod(final DataInput file, final ConstantPool constant_pool) throws IOException, ClassFormatException {
+        this(file, constant_pool, false);
+    }
+
+    /**
+     * Construct object from file stream.
+     * @param file Input stream
+     * @param isOak If the class file is oak
+     * @throws IOException
+     * @throws ClassFormatException
+     */
+    protected FieldOrMethod(final DataInput file, final ConstantPool constant_pool, final boolean isOak) throws IOException, ClassFormatException {
         this(file.readUnsignedShort(), file.readUnsignedShort(), file.readUnsignedShort(), null,
                 constant_pool);
         final int attributes_count = file.readUnsignedShort();
         attributes = new Attribute[attributes_count];
         for (int i = 0; i < attributes_count; i++) {
-            attributes[i] = Attribute.readAttribute(file, constant_pool);
+            attributes[i] = Attribute.readAttribute(file, constant_pool, isOak);
         }
         this.attributes_count = attributes_count; // init deprecated field
     }

--- a/src/main/java/org/apache/bcel/classfile/Method.java
+++ b/src/main/java/org/apache/bcel/classfile/Method.java
@@ -79,7 +79,19 @@ public final class Method extends FieldOrMethod {
      */
     Method(final DataInput file, final ConstantPool constant_pool) throws IOException,
             ClassFormatException {
-        super(file, constant_pool);
+        this(file, constant_pool, false);
+    }
+
+    /**
+     * Construct object from file stream.
+     * @param file Input stream
+     * @param isOak If the class file is oak
+     * @throws IOException
+     * @throws ClassFormatException
+     */
+    Method(final DataInput file, final ConstantPool constant_pool, final boolean isOak) throws IOException,
+            ClassFormatException {
+        super(file, constant_pool, isOak);
     }
 
 


### PR DESCRIPTION
Patches a bug when parsing oak class files (versions <= 45.2)

The code attribute's maxStack, maxLocals, codeLength is half the size (u2 -> u1, u4 -> u2)