### PR TITLE
BCEL-342 Migrate test suite to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,9 +456,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.7.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/bcel/AbstractCounterVisitorTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractCounterVisitorTestCase.java
@@ -21,7 +21,7 @@ package org.apache.bcel;
 import org.apache.bcel.classfile.DescendingVisitor;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.visitors.CounterVisitor;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class AbstractCounterVisitorTestCase extends AbstractTestCase
 {
@@ -29,7 +29,7 @@ public abstract class AbstractCounterVisitorTestCase extends AbstractTestCase
 
     private CounterVisitor visitor = null;
 
-    @Before
+    @BeforeEach
     public void setUp() throws ClassNotFoundException
     {
         visitor = new CounterVisitor();

--- a/src/test/java/org/apache/bcel/AbstractCounterVisitorTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractCounterVisitorTestCase.java
@@ -21,6 +21,7 @@ package org.apache.bcel;
 import org.apache.bcel.classfile.DescendingVisitor;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.visitors.CounterVisitor;
+import org.junit.Before;
 
 public abstract class AbstractCounterVisitorTestCase extends AbstractTestCase
 {
@@ -28,7 +29,7 @@ public abstract class AbstractCounterVisitorTestCase extends AbstractTestCase
 
     private CounterVisitor visitor = null;
 
-    @Override
+    @Before
     public void setUp() throws ClassNotFoundException
     {
         visitor = new CounterVisitor();

--- a/src/test/java/org/apache/bcel/AbstractTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractTestCase.java
@@ -35,9 +35,9 @@ import org.apache.bcel.generic.SimpleElementValueGen;
 import org.apache.bcel.util.ClassPath;
 import org.apache.bcel.util.SyntheticRepository;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
 
-public abstract class AbstractTestCase extends TestCase
+public abstract class AbstractTestCase
 {
     private static final boolean verbose = false;
 

--- a/src/test/java/org/apache/bcel/AbstractTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractTestCase.java
@@ -35,7 +35,7 @@ import org.apache.bcel.generic.SimpleElementValueGen;
 import org.apache.bcel.util.ClassPath;
 import org.apache.bcel.util.SyntheticRepository;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public abstract class AbstractTestCase
 {
@@ -141,8 +141,8 @@ public abstract class AbstractTestCase
                 chosenAttrsList.add(element);
             }
         }
-        assertTrue("Should be one match: " + chosenAttrsList.size(),
-                chosenAttrsList.size() == 1);
+        assertTrue(chosenAttrsList.size() == 1,
+                "Should be one match: " + chosenAttrsList.size());
         return chosenAttrsList.get(0);
     }
 

--- a/src/test/java/org/apache/bcel/AnnotationAccessFlagTestCase.java
+++ b/src/test/java/org/apache/bcel/AnnotationAccessFlagTestCase.java
@@ -19,9 +19,9 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AnnotationAccessFlagTestCase extends AbstractTestCase
 {
@@ -34,12 +34,10 @@ public class AnnotationAccessFlagTestCase extends AbstractTestCase
     public void testAnnotationClassSaysItIs() throws ClassNotFoundException
     {
         JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleAnnotation");
-        assertTrue(
-                "Expected SimpleAnnotation class to say it was an annotation - but it didn't !",
-                clazz.isAnnotation());
+        assertTrue(clazz.isAnnotation(),
+                "Expected SimpleAnnotation class to say it was an annotation - but it didn't !");
         clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleClass");
-        assertTrue(
-                "Expected SimpleClass class to say it was not an annotation - but it didn't !",
-                !clazz.isAnnotation());
+        assertTrue(!clazz.isAnnotation(),
+                "Expected SimpleClass class to say it was not an annotation - but it didn't !");
     }
 }

--- a/src/test/java/org/apache/bcel/AnnotationAccessFlagTestCase.java
+++ b/src/test/java/org/apache/bcel/AnnotationAccessFlagTestCase.java
@@ -19,6 +19,9 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class AnnotationAccessFlagTestCase extends AbstractTestCase
 {
@@ -27,6 +30,7 @@ public class AnnotationAccessFlagTestCase extends AbstractTestCase
      * should be marked as an annotation type - which is detectable through
      * BCEL.
      */
+    @Test
     public void testAnnotationClassSaysItIs() throws ClassNotFoundException
     {
         JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleAnnotation");

--- a/src/test/java/org/apache/bcel/AnnotationDefaultAttributeTestCase.java
+++ b/src/test/java/org/apache/bcel/AnnotationDefaultAttributeTestCase.java
@@ -23,6 +23,9 @@ import org.apache.bcel.classfile.ElementValue;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.classfile.SimpleElementValue;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class AnnotationDefaultAttributeTestCase extends AbstractTestCase
 {
@@ -31,6 +34,7 @@ public class AnnotationDefaultAttributeTestCase extends AbstractTestCase
      * to query the AnnotationDefault attribute against the method to discover
      * the default value that was originally declared.
      */
+    @Test
     public void testMethodAnnotations() throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleAnnotation");

--- a/src/test/java/org/apache/bcel/AnnotationDefaultAttributeTestCase.java
+++ b/src/test/java/org/apache/bcel/AnnotationDefaultAttributeTestCase.java
@@ -23,9 +23,9 @@ import org.apache.bcel.classfile.ElementValue;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.classfile.SimpleElementValue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AnnotationDefaultAttributeTestCase extends AbstractTestCase
 {
@@ -42,9 +42,9 @@ public class AnnotationDefaultAttributeTestCase extends AbstractTestCase
         final AnnotationDefault a = (AnnotationDefault) findAttribute(
                 "AnnotationDefault", m.getAttributes());
         final SimpleElementValue val = (SimpleElementValue) a.getDefaultValue();
-        assertTrue("Should be STRING but is " + val.getElementValueType(), val
-                .getElementValueType() == ElementValue.STRING);
-        assertTrue("Should have default of bananas but default is "
-                + val.getValueString(), val.getValueString().equals("bananas"));
+        assertTrue(val.getElementValueType() == ElementValue.STRING,
+                "Should be STRING but is " + val.getElementValueType());
+        assertTrue(val.getValueString().equals("bananas"),
+                "Should have default of bananas but default is " + val.getValueString());
     }
 }

--- a/src/test/java/org/apache/bcel/AnonymousClassTestCase.java
+++ b/src/test/java/org/apache/bcel/AnonymousClassTestCase.java
@@ -19,9 +19,14 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class AnonymousClassTestCase extends AbstractTestCase
 {
+    @Test
     public void testRegularClassIsNotAnonymous() throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AnonymousClassTest");
@@ -30,6 +35,7 @@ public class AnonymousClassTestCase extends AbstractTestCase
         assertFalse("regular outer classes are not nested", clazz.isNested());
     }
 
+    @Test
     public void testNamedInnerClassIsNotAnonymous()
             throws ClassNotFoundException
     {
@@ -39,6 +45,7 @@ public class AnonymousClassTestCase extends AbstractTestCase
         assertTrue("regular inner classes are nested", clazz.isNested());
     }
 
+    @Test
     public void testStaticInnerClassIsNotAnonymous()
             throws ClassNotFoundException
     {
@@ -48,6 +55,7 @@ public class AnonymousClassTestCase extends AbstractTestCase
         assertTrue("regular static inner classes are nested", clazz.isNested());
     }
 
+    @Test
     public void testAnonymousInnerClassIsAnonymous()
             throws ClassNotFoundException
     {

--- a/src/test/java/org/apache/bcel/AnonymousClassTestCase.java
+++ b/src/test/java/org/apache/bcel/AnonymousClassTestCase.java
@@ -19,10 +19,10 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AnonymousClassTestCase extends AbstractTestCase
 {
@@ -30,9 +30,8 @@ public class AnonymousClassTestCase extends AbstractTestCase
     public void testRegularClassIsNotAnonymous() throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AnonymousClassTest");
-        assertFalse("regular outer classes are not anonymous", clazz
-                .isAnonymous());
-        assertFalse("regular outer classes are not nested", clazz.isNested());
+        assertFalse(clazz.isAnonymous(), "regular outer classes are not anonymous");
+        assertFalse(clazz.isNested(), "regular outer classes are not nested");
     }
 
     @Test
@@ -40,9 +39,8 @@ public class AnonymousClassTestCase extends AbstractTestCase
             throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AnonymousClassTest$X");
-        assertFalse("regular inner classes are not anonymous", clazz
-                .isAnonymous());
-        assertTrue("regular inner classes are nested", clazz.isNested());
+        assertFalse(clazz.isAnonymous(), "regular inner classes are not anonymous");
+        assertTrue(clazz.isNested(), "regular inner classes are nested");
     }
 
     @Test
@@ -50,9 +48,8 @@ public class AnonymousClassTestCase extends AbstractTestCase
             throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AnonymousClassTest$Y");
-        assertFalse("regular static inner classes are not anonymous", clazz
-                .isAnonymous());
-        assertTrue("regular static inner classes are nested", clazz.isNested());
+        assertFalse(clazz.isAnonymous(), "regular static inner classes are not anonymous");
+        assertTrue(clazz.isNested(), "regular static inner classes are nested");
     }
 
     @Test
@@ -60,7 +57,7 @@ public class AnonymousClassTestCase extends AbstractTestCase
             throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AnonymousClassTest$1");
-        assertTrue("anonymous inner classes are anonymous", clazz.isAnonymous());
-        assertTrue("anonymous inner classes are anonymous", clazz.isNested());
+        assertTrue(clazz.isAnonymous(), "anonymous inner classes are anonymous");
+        assertTrue(clazz.isNested(), "anonymous inner classes are anonymous");
     }
 }

--- a/src/test/java/org/apache/bcel/CounterVisitorTestCase.java
+++ b/src/test/java/org/apache/bcel/CounterVisitorTestCase.java
@@ -19,6 +19,9 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class CounterVisitorTestCase extends AbstractCounterVisitorTestCase
 {
@@ -28,186 +31,223 @@ public class CounterVisitorTestCase extends AbstractCounterVisitorTestCase
         return getTestClass(PACKAGE_BASE_NAME+".data.MarkedType");
     }
 
+    @Test
     public void testAnnotationsCount()
     {
         assertEquals("annotationCount", 2, getVisitor().annotationCount);
     }
 
+    @Test
     public void testAnnotationDefaultCount()
     {
         assertEquals("annotationDefaultCount", 0, getVisitor().annotationDefaultCount);
     }
 
+    @Test
     public void testAnnotationEntryCount()
     {
         assertEquals("annotationEntryCount", 2, getVisitor().annotationEntryCount);
     }
 
+    @Test
     public void testCodeCount()
     {
         assertEquals("codeCount", 1, getVisitor().codeCount);
     }
 
+    @Test
     public void testCodeExceptionCount()
     {
         assertEquals("codeExceptionCount", 0, getVisitor().codeExceptionCount);
     }
 
+    @Test
     public void testConstantClassCount()
     {
         assertEquals("constantClassCount", 2, getVisitor().constantClassCount);
     }
 
+    @Test
     public void testConstantDoubleCount()
     {
         assertEquals("constantDoubleCount", 0, getVisitor().constantDoubleCount);
     }
 
+    @Test
     public void testConstantFieldrefCount()
     {
         assertEquals("constantFieldrefCount", 0, getVisitor().constantFieldrefCount);
     }
 
+    @Test
     public void testConstantFloatCount()
     {
         assertEquals("constantFloatCount", 0, getVisitor().constantFloatCount);
     }
 
+    @Test
     public void testConstantIntegerCount()
     {
         assertEquals("constantIntegerCount", 0, getVisitor().constantIntegerCount);
     }
 
+    @Test
     public void testConstantInterfaceMethodrefCount()
     {
         assertEquals("constantInterfaceMethodrefCount", 0, getVisitor().constantInterfaceMethodrefCount);
     }
 
+    @Test
     public void testConstantLongCount()
     {
         assertEquals("constantLongCount", 0, getVisitor().constantLongCount);
     }
 
+    @Test
     public void testConstantMethodrefCount()
     {
         assertEquals("constantMethodrefCount", 1, getVisitor().constantMethodrefCount);
     }
 
+    @Test
     public void testConstantNameAndTypeCount()
     {
         assertEquals("constantNameAndTypeCount", 1, getVisitor().constantNameAndTypeCount);
     }
 
+    @Test
     public void testConstantPoolCount()
     {
         assertEquals("constantPoolCount", 1, getVisitor().constantPoolCount);
     }
 
+    @Test
     public void testConstantStringCount()
     {
         assertEquals("constantStringCount", 0, getVisitor().constantStringCount);
     }
 
+    @Test
     public void testConstantValueCount()
     {
         assertEquals("constantValueCount", 0, getVisitor().constantValueCount);
     }
 
+    @Test
     public void testDeprecatedCount()
     {
         assertEquals("deprecatedCount", 0, getVisitor().deprecatedCount);
     }
 
+    @Test
     public void testEnclosingMethodCount()
     {
         assertEquals("enclosingMethodCount", 0, getVisitor().enclosingMethodCount);
     }
 
+    @Test
     public void testExceptionTableCount()
     {
         assertEquals("exceptionTableCount", 0, getVisitor().exceptionTableCount);
     }
 
+    @Test
     public void testFieldCount()
     {
         assertEquals("fieldCount", 0, getVisitor().fieldCount);
     }
 
+    @Test
     public void testInnerClassCount()
     {
         assertEquals("innerClassCount", 0, getVisitor().innerClassCount);
     }
 
+    @Test
     public void testInnerClassesCount()
     {
         assertEquals("innerClassesCount", 0, getVisitor().innerClassesCount);
     }
 
+    @Test
     public void testJavaClassCount()
     {
         assertEquals("javaClassCount", 1, getVisitor().javaClassCount);
     }
 
+    @Test
     public void testLineNumberCount()
     {
         assertEquals("lineNumberCount", 1, getVisitor().lineNumberCount);
     }
 
+    @Test
     public void testLineNumberTableCount()
     {
         assertEquals("lineNumberTableCount", 1, getVisitor().lineNumberTableCount);
     }
 
+    @Test
     public void testLocalVariableCount()
     {
         assertEquals("localVariableCount", 1, getVisitor().localVariableCount);
     }
 
+    @Test
     public void testLocalVariableTableCount()
     {
         assertEquals("localVariableTableCount", 1, getVisitor().localVariableTableCount);
     }
 
+    @Test
     public void testLocalVariableTypeTableCount()
     {
         assertEquals("localVariableTypeTableCount", 0, getVisitor().localVariableTypeTableCount);
     }
 
+    @Test
     public void testMethodCount()
     {
         assertEquals("methodCount", 1, getVisitor().methodCount);
     }
 
+    @Test
     public void testParameterAnnotationCount()
     {
         assertEquals("parameterAnnotationCount", 0, getVisitor().parameterAnnotationCount);
     }
 
+    @Test
     public void testSignatureCount()
     {
         assertEquals("signatureAnnotationCount", 0, getVisitor().signatureAnnotationCount);
     }
 
+    @Test
     public void testSourceFileCount()
     {
         assertEquals("sourceFileCount", 1, getVisitor().sourceFileCount);
     }
 
+    @Test
     public void testStackMapCount()
     {
         assertEquals("stackMapCount", 0, getVisitor().stackMapCount);
     }
 
+    @Test
     public void testStackMapEntryCount()
     {
         assertEquals("stackMapEntryCount", 0, getVisitor().stackMapEntryCount);
     }
 
+    @Test
     public void testSyntheticCount()
     {
         assertEquals("syntheticCount", 0, getVisitor().syntheticCount);
     }
 
+    @Test
     public void testUnknownCount()
     {
         assertEquals("unknownCount", 0, getVisitor().unknownCount);

--- a/src/test/java/org/apache/bcel/CounterVisitorTestCase.java
+++ b/src/test/java/org/apache/bcel/CounterVisitorTestCase.java
@@ -19,9 +19,9 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CounterVisitorTestCase extends AbstractCounterVisitorTestCase
 {
@@ -34,222 +34,222 @@ public class CounterVisitorTestCase extends AbstractCounterVisitorTestCase
     @Test
     public void testAnnotationsCount()
     {
-        assertEquals("annotationCount", 2, getVisitor().annotationCount);
+        assertEquals(2, getVisitor().annotationCount, "annotationCount");
     }
 
     @Test
     public void testAnnotationDefaultCount()
     {
-        assertEquals("annotationDefaultCount", 0, getVisitor().annotationDefaultCount);
+        assertEquals(0, getVisitor().annotationDefaultCount, "annotationDefaultCount");
     }
 
     @Test
     public void testAnnotationEntryCount()
     {
-        assertEquals("annotationEntryCount", 2, getVisitor().annotationEntryCount);
+        assertEquals(2, getVisitor().annotationEntryCount, "annotationEntryCount");
     }
 
     @Test
     public void testCodeCount()
     {
-        assertEquals("codeCount", 1, getVisitor().codeCount);
+        assertEquals(1, getVisitor().codeCount, "codeCount");
     }
 
     @Test
     public void testCodeExceptionCount()
     {
-        assertEquals("codeExceptionCount", 0, getVisitor().codeExceptionCount);
+        assertEquals(0, getVisitor().codeExceptionCount, "codeExceptionCount");
     }
 
     @Test
     public void testConstantClassCount()
     {
-        assertEquals("constantClassCount", 2, getVisitor().constantClassCount);
+        assertEquals(2, getVisitor().constantClassCount, "constantClassCount");
     }
 
     @Test
     public void testConstantDoubleCount()
     {
-        assertEquals("constantDoubleCount", 0, getVisitor().constantDoubleCount);
+        assertEquals(0, getVisitor().constantDoubleCount, "constantDoubleCount");
     }
 
     @Test
     public void testConstantFieldrefCount()
     {
-        assertEquals("constantFieldrefCount", 0, getVisitor().constantFieldrefCount);
+        assertEquals(0, getVisitor().constantFieldrefCount, "constantFieldrefCount");
     }
 
     @Test
     public void testConstantFloatCount()
     {
-        assertEquals("constantFloatCount", 0, getVisitor().constantFloatCount);
+        assertEquals(0, getVisitor().constantFloatCount, "constantFloatCount");
     }
 
     @Test
     public void testConstantIntegerCount()
     {
-        assertEquals("constantIntegerCount", 0, getVisitor().constantIntegerCount);
+        assertEquals(0, getVisitor().constantIntegerCount, "constantIntegerCount");
     }
 
     @Test
     public void testConstantInterfaceMethodrefCount()
     {
-        assertEquals("constantInterfaceMethodrefCount", 0, getVisitor().constantInterfaceMethodrefCount);
+        assertEquals(0, getVisitor().constantInterfaceMethodrefCount, "constantInterfaceMethodrefCount");
     }
 
     @Test
     public void testConstantLongCount()
     {
-        assertEquals("constantLongCount", 0, getVisitor().constantLongCount);
+        assertEquals(0, getVisitor().constantLongCount, "constantLongCount");
     }
 
     @Test
     public void testConstantMethodrefCount()
     {
-        assertEquals("constantMethodrefCount", 1, getVisitor().constantMethodrefCount);
+        assertEquals(1, getVisitor().constantMethodrefCount, "constantMethodrefCount");
     }
 
     @Test
     public void testConstantNameAndTypeCount()
     {
-        assertEquals("constantNameAndTypeCount", 1, getVisitor().constantNameAndTypeCount);
+        assertEquals(1, getVisitor().constantNameAndTypeCount, "constantNameAndTypeCount");
     }
 
     @Test
     public void testConstantPoolCount()
     {
-        assertEquals("constantPoolCount", 1, getVisitor().constantPoolCount);
+        assertEquals(1, getVisitor().constantPoolCount, "constantPoolCount");
     }
 
     @Test
     public void testConstantStringCount()
     {
-        assertEquals("constantStringCount", 0, getVisitor().constantStringCount);
+        assertEquals(0, getVisitor().constantStringCount, "constantStringCount");
     }
 
     @Test
     public void testConstantValueCount()
     {
-        assertEquals("constantValueCount", 0, getVisitor().constantValueCount);
+        assertEquals(0, getVisitor().constantValueCount, "constantValueCount");
     }
 
     @Test
     public void testDeprecatedCount()
     {
-        assertEquals("deprecatedCount", 0, getVisitor().deprecatedCount);
+        assertEquals(0, getVisitor().deprecatedCount, "deprecatedCount");
     }
 
     @Test
     public void testEnclosingMethodCount()
     {
-        assertEquals("enclosingMethodCount", 0, getVisitor().enclosingMethodCount);
+        assertEquals(0, getVisitor().enclosingMethodCount, "enclosingMethodCount");
     }
 
     @Test
     public void testExceptionTableCount()
     {
-        assertEquals("exceptionTableCount", 0, getVisitor().exceptionTableCount);
+        assertEquals(0, getVisitor().exceptionTableCount, "exceptionTableCount");
     }
 
     @Test
     public void testFieldCount()
     {
-        assertEquals("fieldCount", 0, getVisitor().fieldCount);
+        assertEquals(0, getVisitor().fieldCount, "fieldCount");
     }
 
     @Test
     public void testInnerClassCount()
     {
-        assertEquals("innerClassCount", 0, getVisitor().innerClassCount);
+        assertEquals(0, getVisitor().innerClassCount, "innerClassCount");
     }
 
     @Test
     public void testInnerClassesCount()
     {
-        assertEquals("innerClassesCount", 0, getVisitor().innerClassesCount);
+        assertEquals(0, getVisitor().innerClassesCount, "innerClassesCount");
     }
 
     @Test
     public void testJavaClassCount()
     {
-        assertEquals("javaClassCount", 1, getVisitor().javaClassCount);
+        assertEquals(1, getVisitor().javaClassCount, "javaClassCount");
     }
 
     @Test
     public void testLineNumberCount()
     {
-        assertEquals("lineNumberCount", 1, getVisitor().lineNumberCount);
+        assertEquals(1, getVisitor().lineNumberCount, "lineNumberCount");
     }
 
     @Test
     public void testLineNumberTableCount()
     {
-        assertEquals("lineNumberTableCount", 1, getVisitor().lineNumberTableCount);
+        assertEquals(1, getVisitor().lineNumberTableCount, "lineNumberTableCount");
     }
 
     @Test
     public void testLocalVariableCount()
     {
-        assertEquals("localVariableCount", 1, getVisitor().localVariableCount);
+        assertEquals(1, getVisitor().localVariableCount, "localVariableCount");
     }
 
     @Test
     public void testLocalVariableTableCount()
     {
-        assertEquals("localVariableTableCount", 1, getVisitor().localVariableTableCount);
+        assertEquals(1, getVisitor().localVariableTableCount, "localVariableTableCount");
     }
 
     @Test
     public void testLocalVariableTypeTableCount()
     {
-        assertEquals("localVariableTypeTableCount", 0, getVisitor().localVariableTypeTableCount);
+        assertEquals(0, getVisitor().localVariableTypeTableCount, "localVariableTypeTableCount");
     }
 
     @Test
     public void testMethodCount()
     {
-        assertEquals("methodCount", 1, getVisitor().methodCount);
+        assertEquals(1, getVisitor().methodCount, "methodCount");
     }
 
     @Test
     public void testParameterAnnotationCount()
     {
-        assertEquals("parameterAnnotationCount", 0, getVisitor().parameterAnnotationCount);
+        assertEquals(0, getVisitor().parameterAnnotationCount, "parameterAnnotationCount");
     }
 
     @Test
     public void testSignatureCount()
     {
-        assertEquals("signatureAnnotationCount", 0, getVisitor().signatureAnnotationCount);
+        assertEquals(0, getVisitor().signatureAnnotationCount, "signatureAnnotationCount");
     }
 
     @Test
     public void testSourceFileCount()
     {
-        assertEquals("sourceFileCount", 1, getVisitor().sourceFileCount);
+        assertEquals(1, getVisitor().sourceFileCount, "sourceFileCount");
     }
 
     @Test
     public void testStackMapCount()
     {
-        assertEquals("stackMapCount", 0, getVisitor().stackMapCount);
+        assertEquals(0, getVisitor().stackMapCount, "stackMapCount");
     }
 
     @Test
     public void testStackMapEntryCount()
     {
-        assertEquals("stackMapEntryCount", 0, getVisitor().stackMapEntryCount);
+        assertEquals(0, getVisitor().stackMapEntryCount, "stackMapEntryCount");
     }
 
     @Test
     public void testSyntheticCount()
     {
-        assertEquals("syntheticCount", 0, getVisitor().syntheticCount);
+        assertEquals(0, getVisitor().syntheticCount, "syntheticCount");
     }
 
     @Test
     public void testUnknownCount()
     {
-        assertEquals("unknownCount", 0, getVisitor().unknownCount);
+        assertEquals(0, getVisitor().unknownCount, "unknownCount");
     }
 }

--- a/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
+++ b/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
@@ -31,10 +31,10 @@ import org.apache.bcel.generic.ElementValueGen;
 import org.apache.bcel.generic.EnumElementValueGen;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.SimpleElementValueGen;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ElementValueGenTestCase extends AbstractTestCase
 {
@@ -56,9 +56,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
                 ElementValueGen.PRIMITIVE_INT, cp, 555);
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + cp.lookupInteger(555),
-                evg.getIndex() == cp.lookupInteger(555));
+        assertTrue(evg.getIndex() == cp.lookupInteger(555),
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + cp.lookupInteger(555));
         checkSerialize(evg, cp);
     }
 
@@ -71,9 +71,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
                 ElementValueGen.PRIMITIVE_FLOAT, cp, 111.222f);
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + cp.lookupFloat(111.222f), evg
-                .getIndex() == cp.lookupFloat(111.222f));
+        assertTrue(evg.getIndex() == cp.lookupFloat(111.222f),
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + cp.lookupFloat(111.222f));
         checkSerialize(evg, cp);
     }
 
@@ -87,8 +87,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupDouble(333.44);
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx, evg.getIndex() == idx);
+        assertTrue(evg.getIndex() == idx,
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + idx);
         checkSerialize(evg, cp);
     }
 
@@ -102,8 +103,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupLong(3334455L);
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx, evg.getIndex() == idx);
+        assertTrue(evg.getIndex() == idx,
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + idx);
         checkSerialize(evg, cp);
     }
 
@@ -117,8 +119,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger('t');
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx, evg.getIndex() == idx);
+        assertTrue(evg.getIndex() == idx,
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + idx);
         checkSerialize(evg, cp);
     }
 
@@ -132,8 +135,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger((byte) 'z');
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx, evg.getIndex() == idx);
+        assertTrue(evg.getIndex() == idx,
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + idx);
         checkSerialize(evg, cp);
     }
 
@@ -147,8 +151,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger(1); // 1 == true
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx, evg.getIndex() == idx);
+        assertTrue(evg.getIndex() == idx,
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + idx);
         checkSerialize(evg, cp);
     }
 
@@ -162,8 +167,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger(42);
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx, evg.getIndex() == idx);
+        assertTrue(evg.getIndex() == idx,
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + idx);
         checkSerialize(evg, cp);
     }
 
@@ -179,9 +185,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
                 ElementValueGen.STRING, cp, "hello");
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue("Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + cp.lookupUtf8("hello"), evg
-                .getIndex() == cp.lookupUtf8("hello"));
+        assertTrue(evg.getIndex() == cp.lookupUtf8("hello"),
+                "Should have the same index in the constantpool but "
+                + evg.getIndex() + "!=" + cp.lookupUtf8("hello"));
         checkSerialize(evg, cp);
     }
 
@@ -197,10 +203,9 @@ public class ElementValueGenTestCase extends AbstractTestCase
         final EnumElementValueGen evg = new EnumElementValueGen(enumType, "Red", cp);
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue(
+        assertTrue(evg.getValueIndex() == cp.lookupUtf8("Red"),
                 "The new ElementValue value index should match the contents of the constantpool but "
-                        + evg.getValueIndex() + "!=" + cp.lookupUtf8("Red"),
-                evg.getValueIndex() == cp.lookupUtf8("Red"));
+                        + evg.getValueIndex() + "!=" + cp.lookupUtf8("Red"));
         // BCELBUG: Should the class signature or class name be in the constant
         // pool? (see note in ConstantPool)
         // assertTrue("The new ElementValue type index should match the contents
@@ -219,8 +224,8 @@ public class ElementValueGenTestCase extends AbstractTestCase
         final ConstantPoolGen cp = cg.getConstantPool();
         final ObjectType classType = new ObjectType("java.lang.Integer");
         final ClassElementValueGen evg = new ClassElementValueGen(classType, cp);
-        assertTrue("Unexpected value for contained class: '"
-                + evg.getClassString() + "'", evg.getClassString().contains("Integer"));
+        assertTrue(evg.getClassString().contains("Integer"),
+                "Unexpected value for contained class: '" + evg.getClassString() + "'");
         checkSerialize(evg, cp);
     }
 

--- a/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
+++ b/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
@@ -31,6 +31,10 @@ import org.apache.bcel.generic.ElementValueGen;
 import org.apache.bcel.generic.EnumElementValueGen;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.SimpleElementValueGen;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ElementValueGenTestCase extends AbstractTestCase
 {
@@ -43,6 +47,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
     /**
      * Create primitive element values
      */
+    @Test
     public void testCreateIntegerElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -57,6 +62,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         checkSerialize(evg, cp);
     }
 
+    @Test
     public void testCreateFloatElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -71,6 +77,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         checkSerialize(evg, cp);
     }
 
+    @Test
     public void testCreateDoubleElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -85,6 +92,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         checkSerialize(evg, cp);
     }
 
+    @Test
     public void testCreateLongElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -99,6 +107,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         checkSerialize(evg, cp);
     }
 
+    @Test
     public void testCreateCharElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -113,6 +122,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         checkSerialize(evg, cp);
     }
 
+    @Test
     public void testCreateByteElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -127,6 +137,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         checkSerialize(evg, cp);
     }
 
+    @Test
     public void testCreateBooleanElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -141,6 +152,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         checkSerialize(evg, cp);
     }
 
+    @Test
     public void testCreateShortElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -157,6 +169,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
 
     // //
     // Create string element values
+    @Test
     public void testCreateStringElementValue() throws Exception
     {
         // Create HelloWorld
@@ -174,6 +187,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
 
     // //
     // Create enum element value
+    @Test
     public void testCreateEnumElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");
@@ -198,6 +212,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
 
     // //
     // Create class element value
+    @Test
     public void testCreateClassElementValue() throws Exception
     {
         final ClassGen cg = createClassGen("HelloWorld");

--- a/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
+++ b/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
@@ -26,9 +26,9 @@ import org.apache.bcel.classfile.ConstantPool;
 import org.apache.bcel.classfile.EnclosingMethod;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class EnclosingMethodAttributeTestCase extends AbstractTestCase
@@ -100,7 +100,7 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         // Read in the new version and check it is OK
         final SyntheticRepository repos2 = createRepos(".");
         final JavaClass clazz2 = repos2.loadClass("AttributeTestClassEM02$1");
-        Assert.assertNotNull(clazz2); // Use the variable to avoid a warning
+        assertNotNull(clazz2); // Use the variable to avoid a warning
         final EnclosingMethod em = (EnclosingMethod) encMethodAttrs[0];
         final String enclosingClassName = em.getEnclosingClass().getBytes(pool);
         assertTrue(

--- a/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
+++ b/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
@@ -27,6 +27,9 @@ import org.apache.bcel.classfile.EnclosingMethod;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
 import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class EnclosingMethodAttributeTestCase extends AbstractTestCase
 {
@@ -34,6 +37,7 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
      * Verify for an inner class declared inside the 'main' method that the
      * enclosing method attribute is set correctly.
      */
+    @Test
     public void testCheckMethodLevelNamedInnerClass()
             throws ClassNotFoundException
     {
@@ -57,6 +61,7 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
      * Verify for an inner class declared at the type level that the
      * EnclosingMethod attribute is set correctly (i.e. to a null value)
      */
+    @Test
     public void testCheckClassLevelNamedInnerClass()
             throws ClassNotFoundException
     {
@@ -80,6 +85,7 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
     /**
      * Check that we can save and load the attribute correctly.
      */
+    @Test
     public void testAttributeSerializtion() throws ClassNotFoundException,
             IOException
     {

--- a/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
+++ b/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
@@ -26,10 +26,10 @@ import org.apache.bcel.classfile.ConstantPool;
 import org.apache.bcel.classfile.EnclosingMethod;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EnclosingMethodAttributeTestCase extends AbstractTestCase
 {
@@ -44,17 +44,16 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AttributeTestClassEM01$1S");
         final ConstantPool pool = clazz.getConstantPool();
         final Attribute[] encMethodAttrs = findAttribute("EnclosingMethod", clazz);
-        assertTrue("Expected 1 EnclosingMethod attribute but found "
-                + encMethodAttrs.length, encMethodAttrs.length == 1);
+        assertTrue(encMethodAttrs.length == 1,
+                "Expected 1 EnclosingMethod attribute but found " + encMethodAttrs.length);
         final EnclosingMethod em = (EnclosingMethod) encMethodAttrs[0];
         final String enclosingClassName = em.getEnclosingClass().getBytes(pool);
         final String enclosingMethodName = em.getEnclosingMethod().getName(pool);
-        assertTrue(
+        assertTrue(enclosingClassName.equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM01"),
                 "Expected class name to be '"+PACKAGE_BASE_SIG+"/data/AttributeTestClassEM01' but was "
-                        + enclosingClassName, enclosingClassName
-                        .equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM01"));
-        assertTrue("Expected method name to be 'main' but was "
-                + enclosingMethodName, enclosingMethodName.equals("main"));
+                        + enclosingClassName);
+        assertTrue(enclosingMethodName.equals("main"),
+                "Expected method name to be 'main' but was " + enclosingMethodName);
     }
 
     /**
@@ -68,18 +67,16 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AttributeTestClassEM02$1");
         final ConstantPool pool = clazz.getConstantPool();
         final Attribute[] encMethodAttrs = findAttribute("EnclosingMethod", clazz);
-        assertTrue("Expected 1 EnclosingMethod attribute but found "
-                + encMethodAttrs.length, encMethodAttrs.length == 1);
+        assertTrue(encMethodAttrs.length == 1,
+                "Expected 1 EnclosingMethod attribute but found " + encMethodAttrs.length);
         final EnclosingMethod em = (EnclosingMethod) encMethodAttrs[0];
         final String enclosingClassName = em.getEnclosingClass().getBytes(pool);
-        assertTrue(
+        assertTrue(em.getEnclosingMethodIndex() == 0,
                 "The class is not within a method, so method_index should be null, but it is "
-                        + em.getEnclosingMethodIndex(), em
-                        .getEnclosingMethodIndex() == 0);
-        assertTrue(
+                        + em.getEnclosingMethodIndex());
+        assertTrue(enclosingClassName.equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02"),
                 "Expected class name to be '"+PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02' but was "
-                        + enclosingClassName, enclosingClassName
-                        .equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02"));
+                        + enclosingClassName);
     }
 
     /**
@@ -92,8 +89,8 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AttributeTestClassEM02$1");
         final ConstantPool pool = clazz.getConstantPool();
         final Attribute[] encMethodAttrs = findAttribute("EnclosingMethod", clazz);
-        assertTrue("Expected 1 EnclosingMethod attribute but found "
-                + encMethodAttrs.length, encMethodAttrs.length == 1);
+        assertTrue(encMethodAttrs.length == 1,
+                "Expected 1 EnclosingMethod attribute but found " + encMethodAttrs.length);
         // Write it out
         final File tfile = createTestdataFile("AttributeTestClassEM02$1.class");
         clazz.dump(tfile);
@@ -103,14 +100,12 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         assertNotNull(clazz2); // Use the variable to avoid a warning
         final EnclosingMethod em = (EnclosingMethod) encMethodAttrs[0];
         final String enclosingClassName = em.getEnclosingClass().getBytes(pool);
-        assertTrue(
+        assertTrue(em.getEnclosingMethodIndex() == 0,
                 "The class is not within a method, so method_index should be null, but it is "
-                        + em.getEnclosingMethodIndex(), em
-                        .getEnclosingMethodIndex() == 0);
-        assertTrue(
+                        + em.getEnclosingMethodIndex());
+        assertTrue(enclosingClassName.equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02"),
                 "Expected class name to be '"+PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02' but was "
-                        + enclosingClassName, enclosingClassName
-                        .equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02"));
+                        + enclosingClassName);
         tfile.deleteOnExit();
     }
 }

--- a/src/test/java/org/apache/bcel/EnumAccessFlagTestCase.java
+++ b/src/test/java/org/apache/bcel/EnumAccessFlagTestCase.java
@@ -19,9 +19,9 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EnumAccessFlagTestCase extends AbstractTestCase
 {
@@ -34,12 +34,10 @@ public class EnumAccessFlagTestCase extends AbstractTestCase
     public void testEnumClassSaysItIs() throws ClassNotFoundException
     {
         JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleEnum");
-        assertTrue(
-                "Expected SimpleEnum class to say it was an enum - but it didn't !",
-                clazz.isEnum());
+        assertTrue(clazz.isEnum(),
+                "Expected SimpleEnum class to say it was an enum - but it didn't !");
         clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleClass");
-        assertTrue(
-                "Expected SimpleClass class to say it was not an enum - but it didn't !",
-                !clazz.isEnum());
+        assertTrue(!clazz.isEnum(),
+                "Expected SimpleClass class to say it was not an enum - but it didn't !");
     }
 }

--- a/src/test/java/org/apache/bcel/EnumAccessFlagTestCase.java
+++ b/src/test/java/org/apache/bcel/EnumAccessFlagTestCase.java
@@ -19,6 +19,9 @@
 package org.apache.bcel;
 
 import org.apache.bcel.classfile.JavaClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 public class EnumAccessFlagTestCase extends AbstractTestCase
 {
@@ -27,6 +30,7 @@ public class EnumAccessFlagTestCase extends AbstractTestCase
      * marked such that we can determine from the access flags (through BCEL)
      * that it was originally an enum type declaration.
      */
+    @Test
     public void testEnumClassSaysItIs() throws ClassNotFoundException
     {
         JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleEnum");

--- a/src/test/java/org/apache/bcel/HandleTestCase.java
+++ b/src/test/java/org/apache/bcel/HandleTestCase.java
@@ -23,7 +23,7 @@ import org.apache.bcel.generic.ILOAD;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.NOP;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for https://issues.apache.org/jira/browse/BCEL-267 "Race conditions on

--- a/src/test/java/org/apache/bcel/HandleTestCase.java
+++ b/src/test/java/org/apache/bcel/HandleTestCase.java
@@ -25,8 +25,6 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.NOP;
 import org.junit.Test;
 
-import junit.framework.AssertionFailedError;
-
 /**
  * Test for https://issues.apache.org/jira/browse/BCEL-267 "Race conditions on
  * static fields in BranchHandle and InstructionHandle".
@@ -55,7 +53,7 @@ public class HandleTestCase {
                     if (j > 0) {
                         checkLinkage(handle, j);
                         if (start != ((GOTO) handle.getInstruction()).getTarget()) {
-                            final AssertionFailedError error = new AssertionFailedError(
+                            final AssertionError error = new AssertionError(
                                     "unexpected instruction at index " + j);
                             exception = error;
                             throw error;
@@ -81,7 +79,7 @@ public class HandleTestCase {
         final InstructionHandle prev = ih.getPrev();
         final InstructionHandle next = ih.getNext();
         if ((prev != null && prev.getNext() != ih) || (next != null && next.getPrev() != ih)) {
-            final AssertionFailedError error = new AssertionFailedError("corrupt instruction list at index " + index);
+            final AssertionError error = new AssertionError("corrupt instruction list at index " + index);
             exception = error;
             throw error;
         }
@@ -103,7 +101,7 @@ public class HandleTestCase {
                     final InstructionHandle handle = instructionHandles[j];
                     checkLinkage(handle, j);
                     if (j != ((ILOAD) handle.getInstruction()).getIndex()) {
-                        final AssertionFailedError error = new AssertionFailedError("unexpected instruction at index " + j);
+                        final AssertionError error = new AssertionError("unexpected instruction at index " + j);
                         exception = error;
                         throw error;
                     }

--- a/src/test/java/org/apache/bcel/InstructionFinderTestCase.java
+++ b/src/test/java/org/apache/bcel/InstructionFinderTestCase.java
@@ -24,9 +24,13 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.util.InstructionFinder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class InstructionFinderTestCase extends AbstractTestCase
 {
+    @Test
     public void testSearchAll() throws Exception
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".util.InstructionFinder");

--- a/src/test/java/org/apache/bcel/InstructionFinderTestCase.java
+++ b/src/test/java/org/apache/bcel/InstructionFinderTestCase.java
@@ -24,9 +24,9 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.util.InstructionFinder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InstructionFinderTestCase extends AbstractTestCase
 {

--- a/src/test/java/org/apache/bcel/LocalVariableTypeTableTestCase.java
+++ b/src/test/java/org/apache/bcel/LocalVariableTypeTableTestCase.java
@@ -33,7 +33,7 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.LocalVariableGen;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalVariableTypeTableTestCase extends AbstractTestCase {
 

--- a/src/test/java/org/apache/bcel/PLSETestCase.java
+++ b/src/test/java/org/apache/bcel/PLSETestCase.java
@@ -31,6 +31,9 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class PLSETestCase extends AbstractTestCase
 {
@@ -38,6 +41,7 @@ public class PLSETestCase extends AbstractTestCase
      * BCEL-208: A couple of methods in MethodGen.java need to test for
      * an empty instruction list.
      */
+    @Test
     public void testB208() throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestClass");
@@ -54,6 +58,7 @@ public class PLSETestCase extends AbstractTestCase
     /**
      * BCEL-79:
      */
+    @Test
     public void testB79() throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestClass");
@@ -72,6 +77,7 @@ public class PLSETestCase extends AbstractTestCase
     /**
      * BCEL-262:
      */
+    @Test
     public void testB262() throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestEnum");
@@ -93,6 +99,7 @@ public class PLSETestCase extends AbstractTestCase
     /**
      * BCEL-295:
      */
+    @Test
     public void testB295() throws Exception
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestClass2");
@@ -112,6 +119,7 @@ public class PLSETestCase extends AbstractTestCase
     /**
      * Test to improve BCEL tests code coverage for classfile/Utility.java.
      */
+    @Test
     public void testCoverage() throws ClassNotFoundException, java.io.IOException
     {
         // load a class with a wide variety of byte codes - including tableswitch and lookupswitch

--- a/src/test/java/org/apache/bcel/PLSETestCase.java
+++ b/src/test/java/org/apache/bcel/PLSETestCase.java
@@ -31,9 +31,9 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.InvokeInstruction;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PLSETestCase extends AbstractTestCase
 {
@@ -71,7 +71,7 @@ public class PLSETestCase extends AbstractTestCase
         final MethodGen mg = new MethodGen(m, gen.getClassName(), pool);
         final LocalVariableTable new_lvt = mg.getLocalVariableTable(mg.getConstantPool());
         //System.out.println(new_lvt);
-        assertEquals("number of locals", lvt.getTableLength(), new_lvt.getTableLength());
+        assertEquals(lvt.getTableLength(), new_lvt.getTableLength(), "number of locals");
     }
 
     /**
@@ -113,7 +113,7 @@ public class PLSETestCase extends AbstractTestCase
         final LocalVariableTable new_lvt = mg.getLocalVariableTable(mg.getConstantPool());
         final LocalVariable new_lv = new_lvt.getLocalVariable(2, 4);  // 'i'
         //System.out.println(new_lv);
-        assertEquals("live range length", lv.getLength(), new_lv.getLength());
+        assertEquals(lv.getLength(), new_lv.getLength(), "live range length");
     }
 
     /**

--- a/src/test/java/org/apache/bcel/PerformanceTest.java
+++ b/src/test/java/org/apache/bcel/PerformanceTest.java
@@ -33,11 +33,11 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ClassGen;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
-import org.junit.Assert;
+import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.fail;
 
-public final class PerformanceTest extends TestCase {
+public final class PerformanceTest {
 
     private static final boolean REPORT = Boolean.parseBoolean(System.getProperty("PerformanceTest.report", "true"));
 
@@ -131,6 +131,7 @@ public final class PerformanceTest extends TestCase {
         }
     }
 
+    @Test
     public void testPerformance() {
         final File javaLib = new File(System.getProperty("java.home"), "lib");
         javaLib.listFiles((FileFilter) file -> {
@@ -138,7 +139,7 @@ public final class PerformanceTest extends TestCase {
                 try {
                     test(file);
                 } catch (final IOException e) {
-                    Assert.fail(e.getMessage());
+                    fail(e.getMessage());
                 }
             }
             return false;

--- a/src/test/java/org/apache/bcel/PerformanceTest.java
+++ b/src/test/java/org/apache/bcel/PerformanceTest.java
@@ -33,9 +33,9 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ClassGen;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public final class PerformanceTest {
 

--- a/src/test/java/org/apache/bcel/classfile/CodeExceptionTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/CodeExceptionTestCase.java
@@ -17,7 +17,7 @@
  */
 package org.apache.bcel.classfile;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CodeExceptionTestCase {
 

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -22,8 +22,9 @@ import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 public class ConstantPoolTestCase extends AbstractTestCase {
 
@@ -38,7 +39,7 @@ public class ConstantPoolTestCase extends AbstractTestCase {
             if (method.getName().equals("<init>")) {
                 for (final InstructionHandle instructionHandle : getInstructionHandles(clazz, cp, method)) {
                     final String string = instructionHandle.getInstruction().toString(cp.getConstantPool());
-                    Assert.assertNotNull(string);
+                    assertNotNull(string);
                     // TODO Need real assertions.
                     // System.out.println(string);
                 }

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -22,9 +22,9 @@ import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ConstantPoolTestCase extends AbstractTestCase {
 

--- a/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
@@ -18,6 +18,7 @@
 package org.apache.bcel.classfile;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -29,7 +30,6 @@ import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -45,7 +45,7 @@ public class JDKClassDumpTestCase {
                 try {
                     testJar(file);
                 } catch (final Exception e) {
-                    Assert.fail(e.getMessage());
+                    fail(e.getMessage());
                 }
             }
             return false;

--- a/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
@@ -17,8 +17,8 @@
 
 package org.apache.bcel.classfile;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -30,7 +30,7 @@ import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test that dump() methods work on the JDK classes
@@ -81,7 +81,7 @@ public class JDKClassDumpTestCase {
             int i = 0;
             for (final int out : baos.toByteArray()) {
                 final int in = src.read();
-                assertEquals(name + ": Mismatch at " + i, in, out & 0xFF);
+                assertEquals(in, out & 0xFF, name + ": Mismatch at " + i);
                 i++;
             }
         }

--- a/src/test/java/org/apache/bcel/classfile/LocalVariableTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/LocalVariableTestCase.java
@@ -17,7 +17,7 @@
  */
 package org.apache.bcel.classfile;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalVariableTestCase {
 

--- a/src/test/java/org/apache/bcel/classfile/UtilityTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/UtilityTestCase.java
@@ -17,10 +17,13 @@
 
 package org.apache.bcel.classfile;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class UtilityTestCase extends TestCase {
+import static org.junit.Assert.assertEquals;
 
+public class UtilityTestCase {
+
+    @Test
     public void testSignatureToStringWithGenerics() throws Exception {
     // tests for BCEL-197
         assertEquals("generic signature",

--- a/src/test/java/org/apache/bcel/classfile/UtilityTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/UtilityTestCase.java
@@ -17,57 +17,56 @@
 
 package org.apache.bcel.classfile;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UtilityTestCase {
 
     @Test
     public void testSignatureToStringWithGenerics() throws Exception {
     // tests for BCEL-197
-        assertEquals("generic signature",
-                "java.util.Map<X, java.util.List<Y>>",
-                Utility.signatureToString("Ljava/util/Map<TX;Ljava/util/List<TY;>;>;"));
-        assertEquals("generic signature",
-                "java.util.Set<? extends java.nio.file.OpenOption>"
-                , Utility.signatureToString("Ljava/util/Set<+Ljava/nio/file/OpenOption;>;"));
-        assertEquals("generic signature",
-                "java.nio.file.attribute.FileAttribute<?>[]",
-                Utility.signatureToString("[Ljava/nio/file/attribute/FileAttribute<*>;"));
+        assertEquals("java.util.Map<X, java.util.List<Y>>",
+                Utility.signatureToString("Ljava/util/Map<TX;Ljava/util/List<TY;>;>;"),
+                "generic signature");
+        assertEquals("java.util.Set<? extends java.nio.file.OpenOption>",
+                Utility.signatureToString("Ljava/util/Set<+Ljava/nio/file/OpenOption;>;"),
+                "generic signature");
+        assertEquals("java.nio.file.attribute.FileAttribute<?>[]",
+                Utility.signatureToString("[Ljava/nio/file/attribute/FileAttribute<*>;"),
+                "generic signature");
 
     // tests for BCEL-286
-        assertEquals("generic signature",
-                "boofcv.alg.tracker.tld.TldTracker<boofcv.struct.image.ImageGray<boofcv.struct.image.GrayU8>, boofcv.struct.image.GrayI<boofcv.struct.image.GrayU8>>",
-                Utility.signatureToString("Lboofcv/alg/tracker/tld/TldTracker<Lboofcv/struct/image/ImageGray<Lboofcv/struct/image/GrayU8;>;Lboofcv/struct/image/GrayI<Lboofcv/struct/image/GrayU8;>;>;"));
-        assertEquals("generic signature",
-                "java.util.Map<?, ?>",
-                Utility.signatureToString("Ljava/util/Map<**>;"));
-        assertEquals("generic signature",
-                "com.jme3.util.IntMap<T>.IntMapIterator",
-                Utility.signatureToString("Lcom/jme3/util/IntMap<TT;>.IntMapIterator;"));
+        assertEquals("boofcv.alg.tracker.tld.TldTracker<boofcv.struct.image.ImageGray<boofcv.struct.image.GrayU8>, boofcv.struct.image.GrayI<boofcv.struct.image.GrayU8>>",
+                Utility.signatureToString("Lboofcv/alg/tracker/tld/TldTracker<Lboofcv/struct/image/ImageGray<Lboofcv/struct/image/GrayU8;>;Lboofcv/struct/image/GrayI<Lboofcv/struct/image/GrayU8;>;>;"),
+                "generic signature");
+        assertEquals("java.util.Map<?, ?>", Utility.signatureToString("Ljava/util/Map<**>;"),
+                "generic signature");
+        assertEquals("com.jme3.util.IntMap<T>.IntMapIterator",
+                Utility.signatureToString("Lcom/jme3/util/IntMap<TT;>.IntMapIterator;"),
+                "generic signature");
 
     // tests for BCEL-279
-        assertEquals("type parameters signature",
-                "<T extends java.lang.Object>(com.google.common.io.ByteProcessor<T>, int)T",
-                Utility.signatureToString("<T:Ljava/lang/Object;>(Lcom/google/common/io/ByteProcessor<TT;>;I)TT;", false));
-        assertEquals("type parameters signature",
-                "<T extends Object>(com.google.common.io.ByteProcessor<T>, int)T",
-                Utility.signatureToString("<T:Ljava/lang/Object;>(Lcom/google/common/io/ByteProcessor<TT;>;I)TT;", true));
-        assertEquals("type parameters signature",
-                "<M extends java.lang.reflect.AccessibleObject & java.lang.reflect.Member>(M)void",
-                Utility.signatureToString("<M:Ljava/lang/reflect/AccessibleObject;:Ljava/lang/reflect/Member;>(TM;)V"));
-        assertEquals("type parameters signature",
-                "<K1 extends K, V1 extends V>()com.google.common.cache.Weigher<K1, V1>",
-                Utility.signatureToString("<K1:TK;V1:TV;>()Lcom/google/common/cache/Weigher<TK1;TV1;>;"));
-        assertEquals("type parameters signature",
-                "<K1 extends K, V1 extends V>(com.google.common.cache.Weigher<? super K1, ? super V1>)com.google.common.cache.CacheBuilder<K1, V1>",
-                Utility.signatureToString("<K1:TK;V1:TV;>(Lcom/google/common/cache/Weigher<-TK1;-TV1;>;)Lcom/google/common/cache/CacheBuilder<TK1;TV1;>;"));
-        assertEquals("class signature",
-                "<N extends java.lang.Object, E extends java.lang.Object> extends java.lang.Object implements com.google.common.graph.Network<N, E>",
-                Utility.signatureToString("<N:Ljava/lang/Object;E:Ljava/lang/Object;>Ljava/lang/Object;Lcom/google/common/graph/Network<TN;TE;>;", false));
-        assertEquals("class signature",
-                "<K extends Object, V extends Object> extends Object",
-                Utility.signatureToString("<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;"));
+        assertEquals("<T extends java.lang.Object>(com.google.common.io.ByteProcessor<T>, int)T",
+                Utility.signatureToString("<T:Ljava/lang/Object;>(Lcom/google/common/io/ByteProcessor<TT;>;I)TT;", false),
+                "type parameters signature");
+        assertEquals("<T extends Object>(com.google.common.io.ByteProcessor<T>, int)T",
+                Utility.signatureToString("<T:Ljava/lang/Object;>(Lcom/google/common/io/ByteProcessor<TT;>;I)TT;", true),
+                "type parameters signature");
+        assertEquals("<M extends java.lang.reflect.AccessibleObject & java.lang.reflect.Member>(M)void",
+                Utility.signatureToString("<M:Ljava/lang/reflect/AccessibleObject;:Ljava/lang/reflect/Member;>(TM;)V"),
+                "type parameters signature");
+        assertEquals("<K1 extends K, V1 extends V>()com.google.common.cache.Weigher<K1, V1>",
+                Utility.signatureToString("<K1:TK;V1:TV;>()Lcom/google/common/cache/Weigher<TK1;TV1;>;"),
+                "type parameters signature");
+        assertEquals("<K1 extends K, V1 extends V>(com.google.common.cache.Weigher<? super K1, ? super V1>)com.google.common.cache.CacheBuilder<K1, V1>",
+                Utility.signatureToString("<K1:TK;V1:TV;>(Lcom/google/common/cache/Weigher<-TK1;-TV1;>;)Lcom/google/common/cache/CacheBuilder<TK1;TV1;>;"),
+                "type parameters signature");
+        assertEquals("<N extends java.lang.Object, E extends java.lang.Object> extends java.lang.Object implements com.google.common.graph.Network<N, E>",
+                Utility.signatureToString("<N:Ljava/lang/Object;E:Ljava/lang/Object;>Ljava/lang/Object;Lcom/google/common/graph/Network<TN;TE;>;", false),
+                "class signature");
+        assertEquals("<K extends Object, V extends Object> extends Object",
+                Utility.signatureToString("<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;"),
+                "class signature");
     }
 }

--- a/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
@@ -31,6 +31,11 @@ import org.apache.bcel.classfile.Annotations;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.RuntimeInvisibleAnnotations;
 import org.apache.bcel.classfile.RuntimeVisibleAnnotations;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class AnnotationGenTestCase extends AbstractTestCase
 {
@@ -43,6 +48,7 @@ public class AnnotationGenTestCase extends AbstractTestCase
     /**
      * Programmatically construct an mutable annotation (AnnotationGen) object.
      */
+    @Test
     public void testConstructMutableAnnotation()
     {
         // Create the containing class
@@ -68,6 +74,7 @@ public class AnnotationGenTestCase extends AbstractTestCase
         checkSerialize(a, cp);
     }
 
+    @Test
     public void testVisibleInvisibleAnnotationGen()
     {
         // Create the containing class

--- a/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
@@ -31,11 +31,11 @@ import org.apache.bcel.classfile.Annotations;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.RuntimeInvisibleAnnotations;
 import org.apache.bcel.classfile.RuntimeVisibleAnnotations;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AnnotationGenTestCase extends AbstractTestCase
 {
@@ -61,9 +61,8 @@ public class AnnotationGenTestCase extends AbstractTestCase
         final ElementValuePairGen nvGen = new ElementValuePairGen("id", evg,
                 cp);
         // Check it looks right
-        assertTrue(
-                "Should include string 'id=4' but says: " + nvGen.toString(),
-                nvGen.toString().contains("id=4"));
+        assertTrue(nvGen.toString().contains("id=4"),
+                "Should include string 'id=4' but says: " + nvGen.toString());
         final ObjectType t = new ObjectType("SimpleAnnotation");
         final List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
@@ -87,9 +86,8 @@ public class AnnotationGenTestCase extends AbstractTestCase
         final ElementValuePairGen nvGen = new ElementValuePairGen("id", evg,
                 cp);
         // Check it looks right
-        assertTrue(
-                "Should include string 'id=4' but says: " + nvGen.toString(),
-                nvGen.toString().contains("id=4"));
+        assertTrue(nvGen.toString().contains("id=4"),
+                "Should include string 'id=4' but says: " + nvGen.toString());
         final ObjectType t = new ObjectType("SimpleAnnotation");
         final List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
@@ -107,7 +105,7 @@ public class AnnotationGenTestCase extends AbstractTestCase
                 foundRV = true;
             }
         }
-        assertTrue("Should have seen a RuntimeVisibleAnnotation", foundRV);
+        assertTrue(foundRV, "Should have seen a RuntimeVisibleAnnotation");
         // Build a RIV annotation of type 'SimpleAnnotation' with 'id=4' as the
         // only value :)
         final AnnotationEntryGen a2 = new AnnotationEntryGen(t, elements, false, cp);
@@ -122,7 +120,7 @@ public class AnnotationGenTestCase extends AbstractTestCase
                 foundRIV = true;
             }
         }
-        assertTrue("Should have seen a RuntimeInvisibleAnnotation", foundRIV);
+        assertTrue(foundRIV, "Should have seen a RuntimeInvisibleAnnotation");
     }
 
     private void checkSerialize(final AnnotationEntryGen a, final ConstantPoolGen cpg)

--- a/src/test/java/org/apache/bcel/generic/BranchHandleTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/BranchHandleTestCase.java
@@ -17,8 +17,9 @@
  */
 package org.apache.bcel.generic;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 public class BranchHandleTestCase {
 
@@ -26,25 +27,25 @@ public class BranchHandleTestCase {
     @Test(expected=ClassGenException.class)
     public void testsetInstructionNull() {
         final BranchHandle bh = BranchHandle.getBranchHandle(new GOTO(null));// have to start with a valid BI
-        Assert.assertNotNull(bh);
+        assertNotNull(bh);
         bh.setInstruction(null);
-        Assert.assertNotNull(bh);
+        assertNotNull(bh);
     }
 
     @Test
     public void testsetInstructionBI() {
         final BranchHandle bh = BranchHandle.getBranchHandle(new GOTO(null));// have to start with a valid BI
-        Assert.assertNotNull(bh);
+        assertNotNull(bh);
         bh.setInstruction(new GOTO(null));
-        Assert.assertNotNull(bh);
+        assertNotNull(bh);
     }
 
     @Test(expected=ClassGenException.class)
     public void testsetInstructionnotBI() {
         final BranchHandle bh = BranchHandle.getBranchHandle(new GOTO(null));// have to start with a valid BI
-        Assert.assertNotNull(bh);
+        assertNotNull(bh);
         bh.setInstruction(new NOP());
-        Assert.assertNotNull(bh);
+        assertNotNull(bh);
     }
 
     @Test(expected=ClassGenException.class)

--- a/src/test/java/org/apache/bcel/generic/BranchHandleTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/BranchHandleTestCase.java
@@ -17,19 +17,19 @@
  */
 package org.apache.bcel.generic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class BranchHandleTestCase {
 
     // Test that setInstruction only allows BranchInstructions
-    @Test(expected=ClassGenException.class)
+    @Test
     public void testsetInstructionNull() {
         final BranchHandle bh = BranchHandle.getBranchHandle(new GOTO(null));// have to start with a valid BI
         assertNotNull(bh);
-        bh.setInstruction(null);
-        assertNotNull(bh);
+        assertThrows(ClassGenException.class, () -> bh.setInstruction(null));
     }
 
     @Test
@@ -40,16 +40,15 @@ public class BranchHandleTestCase {
         assertNotNull(bh);
     }
 
-    @Test(expected=ClassGenException.class)
+    @Test
     public void testsetInstructionnotBI() {
         final BranchHandle bh = BranchHandle.getBranchHandle(new GOTO(null));// have to start with a valid BI
         assertNotNull(bh);
-        bh.setInstruction(new NOP());
-        assertNotNull(bh);
+        assertThrows(ClassGenException.class, () -> bh.setInstruction(new NOP()));
     }
 
-    @Test(expected=ClassGenException.class)
+    @Test
     public void testGetBHnull() {
-        BranchHandle.getBranchHandle(null);
+        assertThrows(ClassGenException.class, () -> BranchHandle.getBranchHandle(null));
     }
 }

--- a/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
@@ -27,10 +27,10 @@ import org.apache.bcel.classfile.ElementValuePair;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class FieldAnnotationsTestCase extends AbstractTestCase
 {
@@ -115,8 +115,9 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
             System.err.println("With AnnotationEntrys: "
                     + dumpAnnotationEntries(f.getAnnotationEntries()));
         }
-        assertTrue("Should be 2 AnnotationEntrys on this field, but there are "
-                + f.getAnnotationEntries().length, f.getAnnotationEntries().length == 2);
+        assertTrue(f.getAnnotationEntries().length == 2,
+                "Should be 2 AnnotationEntrys on this field, but there are "
+                        + f.getAnnotationEntries().length);
     }
 
     // helper methods
@@ -138,18 +139,19 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
     private void checkAnnotationEntry(final AnnotationEntry a, final String name, final String elementname,
             final String elementvalue)
     {
-        assertTrue("Expected AnnotationEntry to have name " + name
-                + " but it had name " + a.getAnnotationType(), a.getAnnotationType()
-                .equals(name));
-        assertTrue("Expected AnnotationEntry to have one element but it had "
-                + a.getElementValuePairs().length, a.getElementValuePairs().length == 1);
+        assertTrue(a.getAnnotationType().equals(name),
+                "Expected AnnotationEntry to have name " + name
+                        + " but it had name " + a.getAnnotationType());
+        assertTrue(a.getElementValuePairs().length == 1,
+                "Expected AnnotationEntry to have one element but it had "
+                        + a.getElementValuePairs().length);
         final ElementValuePair envp = a.getElementValuePairs()[0];
-        assertTrue("Expected element name " + elementname + " but was "
-                + envp.getNameString(), elementname
-                .equals(envp.getNameString()));
-        assertTrue("Expected element value " + elementvalue + " but was "
-                + envp.getValue().stringifyValue(), elementvalue.equals(envp
-                .getValue().stringifyValue()));
+        assertTrue(elementname.equals(envp.getNameString()),
+                "Expected element name " + elementname + " but was "
+                        + envp.getNameString());
+        assertTrue(elementvalue.equals(envp.getValue().stringifyValue()),
+                "Expected element value " + elementvalue + " but was "
+                        + envp.getValue().stringifyValue());
     }
 
     // helper methods

--- a/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
@@ -27,12 +27,17 @@ import org.apache.bcel.classfile.ElementValuePair;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class FieldAnnotationsTestCase extends AbstractTestCase
 {
     /**
      * Check field AnnotationEntrys are retrievable.
      */
+    @Test
     public void testFieldAnnotationEntrys() throws ClassNotFoundException
     {
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AnnotatedFields");
@@ -44,6 +49,7 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
     /**
      * Check field AnnotationEntrys (de)serialize ok.
      */
+    @Test
     public void testFieldAnnotationEntrysReadWrite() throws ClassNotFoundException,
             IOException
     {
@@ -64,6 +70,7 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
      * Check we can load in a class, modify its field AnnotationEntrys, save it,
      * reload it and everything is correct.
      */
+    @Test
     public void testFieldAnnotationModification()
             throws ClassNotFoundException
     {

--- a/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
@@ -32,11 +32,11 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.classfile.ParameterAnnotationEntry;
 import org.apache.bcel.classfile.SimpleElementValue;
 import org.apache.bcel.util.SyntheticRepository;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * The program that some of the tests generate looks like this:
@@ -91,28 +91,24 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         dumpClass(cg, "HelloWorld.class");
         final JavaClass jc = getClassFrom(".", "HelloWorld");
         final AnnotationEntry[] as = jc.getAnnotationEntries();
-        assertTrue("Should be two AnnotationEntries but found " + as.length,
-                as.length == 2);
+        assertTrue(as.length == 2,
+                "Should be two AnnotationEntries but found " + as.length);
         // TODO L??;
-        assertTrue(
+        assertTrue(as[0].getAnnotationType().equals("LSimpleAnnotation;"),
                 "Name of annotation 1 should be LSimpleAnnotation; but it is "
-                        + as[0].getAnnotationType(), as[0].getAnnotationType()
-                        .equals("LSimpleAnnotation;"));
-        assertTrue(
+                                + as[0].getAnnotationType());
+        assertTrue(as[1].getAnnotationType().equals("LSimpleAnnotation;"),
                 "Name of annotation 2 should be LSimpleAnnotation; but it is "
-                        + as[1].getAnnotationType(), as[1].getAnnotationType()
-                        .equals("LSimpleAnnotation;"));
+                                + as[1].getAnnotationType());
         final ElementValuePair[] vals = as[0].getElementValuePairs();
         final ElementValuePair nvp = vals[0];
-        assertTrue(
-                "Name of element in SimpleAnnotation should be 'id' but it is "
-                        + nvp.getNameString(), nvp.getNameString().equals("id"));
+        assertTrue(nvp.getNameString().equals("id"),
+                "Name of element in SimpleAnnotation should be 'id' but it is " + nvp.getNameString());
         final ElementValue ev = nvp.getValue();
-        assertTrue("Type of element value should be int but it is "
-                + ev.getElementValueType(),
-                ev.getElementValueType() == ElementValue.PRIMITIVE_INT);
-        assertTrue("Value of element should be 4 but it is "
-                + ev.stringifyValue(), ev.stringifyValue().equals("4"));
+        assertTrue(ev.getElementValueType() == ElementValue.PRIMITIVE_INT,
+                "Type of element value should be int but it is " + ev.getElementValueType());
+        assertTrue(ev.stringifyValue().equals("4"),
+                "Value of element should be 4 but it is " + ev.stringifyValue());
         assertTrue(createTestdataFile("HelloWorld.class").delete());
     }
 
@@ -131,27 +127,26 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         buildClassContentsWithAnnotatedMethods(cg, cp, il);
         // Check annotation is OK
         int i = cg.getMethods()[0].getAnnotationEntries().length;
-        assertTrue(
-                "Prior to dumping, main method should have 1 annotation but has "
-                        + i, i == 1);
+        assertTrue(i == 1,
+                "Prior to dumping, main method should have 1 annotation but has " + i);
         dumpClass(cg, "temp1" + File.separator + "HelloWorld.class");
         final JavaClass jc2 = getClassFrom("temp1", "HelloWorld");
         // Check annotation is OK
         i = jc2.getMethods()[0].getAnnotationEntries().length;
-        assertTrue("JavaClass should say 1 annotation on main method but says "
-                + i, i == 1);
+        assertTrue(i == 1,
+                "JavaClass should say 1 annotation on main method but says " + i);
         final ClassGen cg2 = new ClassGen(jc2);
         // Check it now it is a ClassGen
         final Method[] m = cg2.getMethods();
         i = m[0].getAnnotationEntries().length;
-        assertTrue("The main 'Method' should have one annotation but has " + i,
-                i == 1);
+        assertTrue(i == 1,
+                "The main 'Method' should have one annotation but has " + i);
         final MethodGen mg = new MethodGen(m[0], cg2.getClassName(), cg2
                 .getConstantPool());
         // Check it finally when the Method is changed to a MethodGen
         i = mg.getAnnotationEntries().length;
-        assertTrue("The main 'MethodGen' should have one annotation but has "
-                + i, i == 1);
+        assertTrue(i == 1,
+                "The main 'MethodGen' should have one annotation but has " + i);
 
         assertTrue(wipe("temp1", "HelloWorld.class"));
     }
@@ -176,14 +171,14 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cg2 = new ClassGen(jc2);
         // Main method after reading the class back in
         final Method mainMethod1 = jc2.getMethods()[0];
-        assertTrue("The 'Method' should have one annotations but has "
-                + mainMethod1.getAnnotationEntries().length, mainMethod1
-                .getAnnotationEntries().length == 1);
+        assertTrue(mainMethod1.getAnnotationEntries().length == 1,
+                "The 'Method' should have one annotations but has "
+                        + mainMethod1.getAnnotationEntries().length);
         final MethodGen mainMethod2 = new MethodGen(mainMethod1, cg2.getClassName(),
                 cg2.getConstantPool());
-        assertTrue("The 'MethodGen' should have one annotation but has "
-                + mainMethod2.getAnnotationEntries().length, mainMethod2
-                .getAnnotationEntries().length == 1);
+        assertTrue(mainMethod2.getAnnotationEntries().length == 1,
+                "The 'MethodGen' should have one annotation but has "
+                        + mainMethod2.getAnnotationEntries().length);
         AnnotationEntryGen fruit = createFruitAnnotation(cg2.getConstantPool(), "Pear");
         mainMethod2.addAnnotationEntry(fruit);
         cg2.removeMethod(mainMethod1);
@@ -193,16 +188,16 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cg3 = new ClassGen(jc3);
         final Method mainMethod3 = cg3.getMethods()[1];
         final int i = mainMethod3.getAnnotationEntries().length;
-        assertTrue("The 'Method' should now have two annotations but has " + i,
-                i == 2);
+        assertTrue(i == 2,
+                "The 'Method' should now have two annotations but has " + i);
         mainMethod2.removeAnnotationEntry(fruit);
-        assertTrue("The 'MethodGen' should have one annotation but has "
-                + mainMethod2.getAnnotationEntries().length, mainMethod2
-                .getAnnotationEntries().length == 1);
+        assertTrue(mainMethod2.getAnnotationEntries().length == 1,
+                "The 'MethodGen' should have one annotation but has "
+                        + mainMethod2.getAnnotationEntries().length);
         mainMethod2.removeAnnotationEntries();
-        assertTrue("The 'MethodGen' should have no annotations but has "
-                + mainMethod2.getAnnotationEntries().length, mainMethod2
-                .getAnnotationEntries().length == 0);
+        assertTrue(mainMethod2.getAnnotationEntries().length == 0,
+                "The 'MethodGen' should have no annotations but has "
+                        + mainMethod2.getAnnotationEntries().length);
         assertTrue(wipe("temp2", "HelloWorld.class"));
         assertTrue(wipe("temp3", "HelloWorld.class"));
     }
@@ -219,8 +214,8 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue("Expected one annotation but found " + annotations.length,
-                annotations.length == 1);
+        assertTrue(annotations.length == 1,
+                "Expected one annotation but found " + annotations.length);
     }
 
     /**
@@ -235,8 +230,8 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue("Expected one annotation but found " + annotations.length,
-                annotations.length == 1);
+        assertTrue(annotations.length == 1,
+                "Expected one annotation but found " + annotations.length);
     }
 
     /**
@@ -251,29 +246,27 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue("Expected one annotation but found " + annotations.length,
-                annotations.length == 1);
+        assertTrue(annotations.length == 1,
+                "Expected one annotation but found " + annotations.length);
         final AnnotationEntryGen a = annotations[0];
-        assertTrue("That annotation should only have one value but has "
-                + a.getValues().size(), a.getValues().size() == 1);
+        assertTrue(a.getValues().size() == 1,
+                "That annotation should only have one value but has " + a.getValues().size());
         final ElementValuePairGen nvp = a.getValues().get(0);
         final ElementValueGen value = nvp.getValue();
-        assertTrue("Value should be ArrayElementValueGen but is " + value,
-                value instanceof ArrayElementValueGen);
+        assertTrue(value instanceof ArrayElementValueGen,
+                "Value should be ArrayElementValueGen but is " + value);
         final ArrayElementValueGen arrayValue = (ArrayElementValueGen) value;
-        assertTrue("Array value should be size one but is "
-                + arrayValue.getElementValuesSize(), arrayValue
-                .getElementValuesSize() == 1);
+        assertTrue(arrayValue.getElementValuesSize() == 1,
+                "Array value should be size one but is " + arrayValue.getElementValuesSize());
         final ElementValueGen innerValue = arrayValue.getElementValues().get(0);
         assertTrue(
-                "Value in the array should be AnnotationElementValueGen but is "
-                        + innerValue,
-                innerValue instanceof AnnotationElementValueGen);
+                innerValue instanceof AnnotationElementValueGen,
+                "Value in the array should be AnnotationElementValueGen but is " + innerValue);
         final AnnotationElementValueGen innerAnnotationValue = (AnnotationElementValueGen) innerValue;
-        assertTrue("Should be called L"+PACKAGE_BASE_SIG+"/data/SimpleAnnotation; but is called: "
-                + innerAnnotationValue.getAnnotation().getTypeName(),
-                innerAnnotationValue.getAnnotation().getTypeSignature().equals(
-                        "L"+PACKAGE_BASE_SIG+"/data/SimpleAnnotation;"));
+        assertTrue(innerAnnotationValue.getAnnotation().getTypeSignature().equals(
+                                "L"+PACKAGE_BASE_SIG+"/data/SimpleAnnotation;"),
+                "Should be called L"+PACKAGE_BASE_SIG+"/data/SimpleAnnotation; but is called: "
+                        + innerAnnotationValue.getAnnotation().getTypeName());
 
         // check the three methods
         final Method[] methods = cgen.getMethods();
@@ -305,7 +298,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
     {
         final String methodName= method.getName();
         final AnnotationEntry[] annos= method.getAnnotationEntries();
-        assertEquals("For "+methodName, expectedNumberAnnotations, annos.length);
+        assertEquals(expectedNumberAnnotations, annos.length, "For " + methodName);
         if(expectedNumberAnnotations!=0)
         {
             assertArrayElementValue(nExpectedArrayValues, annos[0]);
@@ -325,14 +318,14 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
     {
         final String methodName= "For "+method.getName();
         final ParameterAnnotationEntry[] parameterAnnotations= method.getParameterAnnotationEntries();
-        assertEquals(methodName, expectedNumberOfParmeterAnnotations.length, parameterAnnotations.length);
+        assertEquals(expectedNumberOfParmeterAnnotations.length, parameterAnnotations.length, methodName);
 
         int i= 0;
         for (final ParameterAnnotationEntry parameterAnnotation : parameterAnnotations)
         {
             final AnnotationEntry[] annos= parameterAnnotation.getAnnotationEntries();
             final int expectedLength = expectedNumberOfParmeterAnnotations[i++];
-            assertEquals(methodName+" parameter "+i, expectedLength, annos.length);
+            assertEquals(expectedLength, annos.length, methodName + " parameter " + i);
             if(expectedLength!=0)
             {
                 assertSimpleElementValue(annos[0]);
@@ -359,8 +352,8 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue("Expected one annotation but found " + annotations.length,
-                annotations.length == 1);
+        assertTrue(annotations.length == 1,
+                "Expected one annotation but found " + annotations.length);
         final List<?> l = annotations[0].getValues();
         boolean found = false;
         for (final Object name : l) {
@@ -373,8 +366,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
                 }
             }
         }
-        assertTrue("Did not find double annotation value with value 33.4",
-                found);
+        assertTrue(found, "Did not find double annotation value with value 33.4");
     }
 
     /**
@@ -388,9 +380,8 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         final ConstantPoolGen cp = cgen.getConstantPool();
         cgen.addAnnotationEntry(createFruitAnnotation(cp, "Pineapple"));
-        assertTrue("Should now have two annotations but has "
-                + cgen.getAnnotationEntries().length, cgen
-                .getAnnotationEntries().length == 2);
+        assertTrue(cgen.getAnnotationEntries().length == 2,
+                "Should now have two annotations but has " + cgen.getAnnotationEntries().length);
         dumpClass(cgen, "SimpleAnnotatedClass.class");
         assertTrue(wipe("SimpleAnnotatedClass.class"));
     }
@@ -406,9 +397,8 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         final ConstantPoolGen cp = cgen.getConstantPool();
         cgen.addAnnotationEntry(createCombinedAnnotation(cp));
-        assertTrue("Should now have two annotations but has "
-                + cgen.getAnnotationEntries().length, cgen
-                .getAnnotationEntries().length == 2);
+        assertTrue(cgen.getAnnotationEntries().length == 2,
+                "Should now have two annotations but has " + cgen.getAnnotationEntries().length);
         dumpClass(cgen, "SimpleAnnotatedClass.class");
         final JavaClass jc2 = getClassFrom(".", "SimpleAnnotatedClass");
         jc2.getAnnotationEntries();

--- a/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
@@ -32,6 +32,11 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.classfile.ParameterAnnotationEntry;
 import org.apache.bcel.classfile.SimpleElementValue;
 import org.apache.bcel.util.SyntheticRepository;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * The program that some of the tests generate looks like this:
@@ -69,6 +74,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
      * <li>Check the attributes are OK</li>
      * </ol>
      */
+    @Test
     public void testGenerateClassLevelAnnotations()
             throws ClassNotFoundException
     {
@@ -114,6 +120,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
      * Just check that we can dump a class that has a method annotation on it
      * and it is still there when we read it back in
      */
+    @Test
     public void testGenerateMethodLevelAnnotations1()
             throws ClassNotFoundException
     {
@@ -155,6 +162,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
      * back in and verify both annotations are there !
      * Also check that we can remove method annotations.
      */
+    @Test
     public void testGenerateMethodLevelAnnotations2()
             throws ClassNotFoundException
     {
@@ -203,6 +211,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
     /**
      * Transform simple class from an immutable to a mutable object.
      */
+    @Test
     public void testTransformClassToClassGen_SimpleTypes()
             throws ClassNotFoundException
     {
@@ -218,6 +227,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
      * Transform simple class from an immutable to a mutable object. The class
      * is annotated with an annotation that uses an enum.
      */
+    @Test
     public void testTransformClassToClassGen_EnumType()
             throws ClassNotFoundException
     {
@@ -233,6 +243,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
      * Transform simple class from an immutable to a mutable object. The class
      * is annotated with an annotation that uses an array of SimpleAnnotations.
      */
+    @Test
     public void testTransformClassToClassGen_ArrayAndAnnotationTypes()
             throws ClassNotFoundException
     {
@@ -340,6 +351,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
     /**
      * Transform complex class from an immutable to a mutable object.
      */
+    @Test
     public void testTransformComplexClassToClassGen()
             throws ClassNotFoundException
     {
@@ -369,6 +381,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
      * Load a class in and modify it with a new attribute - A SimpleAnnotation
      * annotation
      */
+    @Test
     public void testModifyingClasses1() throws ClassNotFoundException
     {
         final JavaClass jc = getTestClass(PACKAGE_BASE_NAME+".data.SimpleAnnotatedClass");
@@ -386,6 +399,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
      * Load a class in and modify it with a new attribute - A ComplexAnnotation
      * annotation
      */
+    @Test
     public void testModifyingClasses2() throws ClassNotFoundException
     {
         final JavaClass jc = getTestClass(PACKAGE_BASE_NAME+".data.SimpleAnnotatedClass");

--- a/src/test/java/org/apache/bcel/generic/InstructionHandleTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/InstructionHandleTestCase.java
@@ -17,20 +17,20 @@
  */
 package org.apache.bcel.generic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InstructionHandleTestCase {
 
     // Test that setInstruction only allows Instructions that are not BranchInstructions
 
-    @Test(expected=ClassGenException.class)
+    @Test
     public void testsetInstructionNull() {
         final InstructionHandle ih = InstructionHandle.getInstructionHandle(new NOP());// have to start with a valid non BI
         assertNotNull(ih);
-        ih.setInstruction(null);
-        assertNotNull(ih);
+        assertThrows(ClassGenException.class, () -> ih.setInstruction(null));
     }
 
     @Test
@@ -41,17 +41,16 @@ public class InstructionHandleTestCase {
         assertNotNull(ih);
     }
 
-    @Test(expected=ClassGenException.class)
+    @Test
     public void testsetInstructionnotI() {
         final InstructionHandle ih = InstructionHandle.getInstructionHandle(new NOP());// have to start with a valid non BI
         assertNotNull(ih);
-        ih.setInstruction(new GOTO(null));
-        assertNotNull(ih);
+        assertThrows(ClassGenException.class, () -> ih.setInstruction(new GOTO(null)));
     }
 
-    @Test(expected=ClassGenException.class)
+    @Test
     public void testGetIHnull() {
-        InstructionHandle.getInstructionHandle(null);
+        assertThrows(ClassGenException.class, () -> InstructionHandle.getInstructionHandle(null));
     }
 
     @Test

--- a/src/test/java/org/apache/bcel/generic/InstructionHandleTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/InstructionHandleTestCase.java
@@ -17,8 +17,9 @@
  */
 package org.apache.bcel.generic;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 public class InstructionHandleTestCase {
 
@@ -27,25 +28,25 @@ public class InstructionHandleTestCase {
     @Test(expected=ClassGenException.class)
     public void testsetInstructionNull() {
         final InstructionHandle ih = InstructionHandle.getInstructionHandle(new NOP());// have to start with a valid non BI
-        Assert.assertNotNull(ih);
+        assertNotNull(ih);
         ih.setInstruction(null);
-        Assert.assertNotNull(ih);
+        assertNotNull(ih);
     }
 
     @Test
     public void testsetInstructionI() {
         final InstructionHandle ih = InstructionHandle.getInstructionHandle(new NOP());// have to start with a valid non BI
-        Assert.assertNotNull(ih);
+        assertNotNull(ih);
         ih.setInstruction(new NOP());
-        Assert.assertNotNull(ih);
+        assertNotNull(ih);
     }
 
     @Test(expected=ClassGenException.class)
     public void testsetInstructionnotI() {
         final InstructionHandle ih = InstructionHandle.getInstructionHandle(new NOP());// have to start with a valid non BI
-        Assert.assertNotNull(ih);
+        assertNotNull(ih);
         ih.setInstruction(new GOTO(null));
-        Assert.assertNotNull(ih);
+        assertNotNull(ih);
     }
 
     @Test(expected=ClassGenException.class)

--- a/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
@@ -19,6 +19,8 @@ package org.apache.bcel.generic;
 
 import static com.sun.jna.platform.win32.WinReg.HKEY_LOCAL_MACHINE;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -49,7 +51,6 @@ import org.apache.bcel.util.ModularRuntimeImage;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -92,7 +93,7 @@ public class JdkGenericDumpTestCase {
                 try (final InputStream inputStream = Files.newInputStream(path)) {
                     final ClassParser classParser = new ClassParser(inputStream, name.toAbsolutePath().toString());
                     final JavaClass javaClass = classParser.parse();
-                    Assert.assertNotNull(javaClass);
+                    assertNotNull(javaClass);
                 }
 
             }
@@ -282,7 +283,7 @@ public class JdkGenericDumpTestCase {
         Assume.assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
         try (final ModularRuntimeImage mri = new ModularRuntimeImage(javaHome)) {
             final List<Path> modules = mri.modules();
-            Assert.assertFalse(modules.isEmpty());
+            assertFalse(modules.isEmpty());
             for (final Path path : modules) {
                 Files.walkFileTree(path, new ClassParserFilesVisitor("*.class"));
             }

--- a/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -51,7 +52,6 @@ import org.apache.bcel.util.ModularRuntimeImage;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -280,7 +280,7 @@ public class JdkGenericDumpTestCase {
 
     @Test
     public void testJreModules() throws Exception {
-        Assume.assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
+        assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
         try (final ModularRuntimeImage mri = new ModularRuntimeImage(javaHome)) {
             final List<Path> modules = mri.modules();
             assertFalse(modules.isEmpty());

--- a/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
@@ -18,11 +18,11 @@
 package org.apache.bcel.generic;
 
 import static com.sun.jna.platform.win32.WinReg.HKEY_LOCAL_MACHINE;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -36,13 +36,13 @@ import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Stream;
 
 import org.apache.bcel.classfile.ClassParser;
 import org.apache.bcel.classfile.Code;
@@ -52,12 +52,10 @@ import org.apache.bcel.util.ModularRuntimeImage;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 import com.sun.jna.platform.win32.Advapi32Util;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test that the generic dump() methods work on the JDK classes Reads each class into an instruction list and then dumps
@@ -74,7 +72,6 @@ import com.sun.jna.platform.win32.Advapi32Util;
  * mvn test -Dtest=JdkGenericDumpTestCase -DExtraJavaHomes="C:\Program Files\Java\openjdk\jdk-13;C:\Program Files\Java\openjdk\jdk-14"
  * </pre>
  */
-@RunWith(Parameterized.class)
 public class JdkGenericDumpTestCase {
 
     private static final String EXTRA_JAVA_HOMES = "ExtraJavaHomes";
@@ -128,10 +125,11 @@ public class JdkGenericDumpTestCase {
 
     private static final String KEY_JRE_9 = "SOFTWARE\\JavaSoft\\JRE";
 
-    private static void addAllJavaHomesOnWindows(final String keyJre, final Set<String> javaHomes) {
+    private static Stream<String> getAllJavaHomesOnWindows(final String keyJre) {
         if (Advapi32Util.registryKeyExists(HKEY_LOCAL_MACHINE, keyJre)) {
-            javaHomes.addAll(findJavaHomesOnWindows(keyJre, Advapi32Util.registryGetKeys(HKEY_LOCAL_MACHINE, keyJre)));
+            return findJavaHomesOnWindows(keyJre, Advapi32Util.registryGetKeys(HKEY_LOCAL_MACHINE, keyJre));
         }
+        return Stream.empty();
     }
 
     private static String bytesToHex(final byte[] bytes) {
@@ -146,44 +144,35 @@ public class JdkGenericDumpTestCase {
         return new String(hexChars);
     }
 
-    @Parameters(name = "{0}")
-    public static Collection<String> data() {
-        return findJavaHomes();
-    }
-
-    private static Set<String> findJavaHomes() {
+    public static Stream<String> findJavaHomes() {
         if (SystemUtils.IS_OS_WINDOWS) {
             return findJavaHomesOnWindows();
         }
-        final Set<String> javaHomes = new HashSet<>(1);
-        javaHomes.add(SystemUtils.JAVA_HOME);
-        return javaHomes;
+        return Stream.of(SystemUtils.JAVA_HOME);
     }
 
-    private static Set<String> findJavaHomesOnWindows() {
-        final Set<String> javaHomes = new HashSet<>();
-        addAllJavaHomesOnWindows(KEY_JRE, javaHomes);
-        addAllJavaHomesOnWindows(KEY_JRE_9, javaHomes);
-        addAllJavaHomesOnWindows(KEY_JDK, javaHomes);
-        addAllJavaHomesOnWindows(KEY_JDK_9, javaHomes);
-        addAllJavaHomesFromKey(EXTRA_JAVA_HOMES, javaHomes);
-        return javaHomes;
+    private static Stream<String> findJavaHomesOnWindows() {
+        return Stream.concat(
+                Stream.of(KEY_JRE, KEY_JRE_9, KEY_JDK, KEY_JDK_9)
+                        .flatMap(JdkGenericDumpTestCase::getAllJavaHomesOnWindows),
+                getAllJavaHomesFromKey(EXTRA_JAVA_HOMES)
+        ).distinct();
     }
 
-    private static void addAllJavaHomesFromKey(final String extraJavaHomesKey, final Set<String> javaHomes) {
-        addAllJavaHomesFromPath(javaHomes, System.getProperty(extraJavaHomesKey));
-        addAllJavaHomesFromPath(javaHomes, System.getenv(extraJavaHomesKey));
+    private static Stream<String> getAllJavaHomesFromKey(final String extraJavaHomesKey) {
+        return Stream.concat(
+                getAllJavaHomesFromPath(System.getProperty(extraJavaHomesKey)),
+                getAllJavaHomesFromPath(System.getenv(extraJavaHomesKey)));
     }
 
-    private static void addAllJavaHomesFromPath(final Set<String> javaHomes, final String path) {
+    private static Stream<String> getAllJavaHomesFromPath(final String path) {
         if (StringUtils.isEmpty(path)) {
-            return;
+            return Stream.empty();
         }
-        final String[] paths = path.split(File.pathSeparator);
-        javaHomes.addAll(Arrays.asList(paths));
+        return Arrays.stream(path.split(File.pathSeparator));
     }
 
-    private static Set<String> findJavaHomesOnWindows(final String keyJavaHome, final String[] keys) {
+    private static Stream<String> findJavaHomesOnWindows(final String keyJavaHome, final String[] keys) {
         final Set<String> javaHomes = new HashSet<>(keys.length);
         for (final String key : keys) {
             if (Advapi32Util.registryKeyExists(HKEY_LOCAL_MACHINE, keyJavaHome + "\\" + key)) {
@@ -196,13 +185,7 @@ public class JdkGenericDumpTestCase {
                 }
             }
         }
-        return javaHomes;
-    }
-
-    private final String javaHome;
-
-    public JdkGenericDumpTestCase(final String javaHome) {
-        this.javaHome = javaHome;
+        return javaHomes.stream();
     }
 
     private void compare(final String name, final Method method) {
@@ -215,7 +198,7 @@ public class JdkGenericDumpTestCase {
         final InstructionList instructionList = new InstructionList(src);
         final byte[] out = instructionList.getByteCode();
         if (src.length == out.length) {
-            assertArrayEquals(name + ": " + method.toString(), src, out);
+            assertArrayEquals(src, out, name + ": " + method.toString());
         } else {
             System.out.println(name + ": " + method.toString() + " " + src.length + " " + out.length);
             System.out.println(bytesToHex(src));
@@ -227,12 +210,12 @@ public class JdkGenericDumpTestCase {
         }
     }
 
-    private File[] listJdkJars() throws Exception {
+    private File[] listJdkJars(String javaHome) throws Exception {
         final File javaLib = new File(javaHome, "lib");
         return javaLib.listFiles((FileFilter) file -> file.getName().endsWith(".jar"));
     }
 
-    private File[] listJdkModules() throws Exception {
+    private File[] listJdkModules(String javaHome) throws Exception {
         final File javaLib = new File(javaHome, "jmods");
         return javaLib.listFiles((FileFilter) file -> file.getName().endsWith(".jmod"));
     }
@@ -258,9 +241,10 @@ public class JdkGenericDumpTestCase {
         }
     }
 
-    @Test
-    public void testJdkJars() throws Exception {
-        final File[] jars = listJdkJars();
+    @ParameterizedTest
+    @MethodSource("findJavaHomes")
+    public void testJdkJars(String javaHome) throws Exception {
+        final File[] jars = listJdkJars(javaHome);
         if (jars != null) {
             for (final File file : jars) {
                 testJar(file);
@@ -268,9 +252,10 @@ public class JdkGenericDumpTestCase {
         }
     }
 
-    @Test
-    public void testJdkModules() throws Exception {
-        final File[] jmods = listJdkModules();
+    @ParameterizedTest
+    @MethodSource("findJavaHomes")
+    public void testJdkModules(String javaHome) throws Exception {
+        final File[] jmods = listJdkModules(javaHome);
         if (jmods != null) {
             for (final File file : jmods) {
                 testJar(file);
@@ -278,8 +263,9 @@ public class JdkGenericDumpTestCase {
         }
     }
 
-    @Test
-    public void testJreModules() throws Exception {
+    @ParameterizedTest
+    @MethodSource("findJavaHomes")
+    public void testJreModules(String javaHome) throws Exception {
         assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
         try (final ModularRuntimeImage mri = new ModularRuntimeImage(javaHome)) {
             final List<Path> modules = mri.modules();

--- a/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
@@ -23,10 +23,16 @@ import java.util.List;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
-import org.junit.Assert;
 import org.junit.Test;
 
 import javax.mail.internet.MailDateFormat;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class MethodGenTestCase {
 
@@ -61,7 +67,7 @@ public class MethodGenTestCase {
             }
         }
 
-        Assert.fail("Method " + name + " not found in class " + cls);
+        fail("Method " + name + " not found in class " + cls);
         return null;
     }
 
@@ -71,9 +77,9 @@ public class MethodGenTestCase {
         final ClassGen cg = new ClassGen(jc);
         final MethodGen mg = new MethodGen(cg.getMethodAt(0), cg.getClassName(), cg.getConstantPool());
         final List<AnnotationEntryGen> firstParamAnnotations = mg.getAnnotationsOnParameter(0);
-        Assert.assertEquals("Wrong number of annotations in the first parameter", 1, firstParamAnnotations.size());
+        assertEquals("Wrong number of annotations in the first parameter", 1, firstParamAnnotations.size());
         final List<AnnotationEntryGen> secondParamAnnotations = mg.getAnnotationsOnParameter(1);
-        Assert.assertEquals("Wrong number of annotations in the second parameter", 1, secondParamAnnotations.size());
+        assertEquals("Wrong number of annotations in the second parameter", 1, secondParamAnnotations.size());
     }
 
     @Test
@@ -81,21 +87,21 @@ public class MethodGenTestCase {
         final MethodGen mg = getMethod(Foo.class, "bar");
 
         final LocalVariableGen lv = mg.getLocalVariables()[1];
-        Assert.assertEquals("variable name", "a", lv.getName());
+        assertEquals("variable name", "a", lv.getName());
         final InstructionHandle start = lv.getStart();
         final InstructionHandle end = lv.getEnd();
-        Assert.assertNotNull("scope start", start);
-        Assert.assertNotNull("scope end", end);
-        Assert.assertTrue("scope start not targeted by the local variable", Arrays.asList(start.getTargeters()).contains(lv));
-        Assert.assertTrue("scope end not targeted by the local variable", Arrays.asList(end.getTargeters()).contains(lv));
+        assertNotNull("scope start", start);
+        assertNotNull("scope end", end);
+        assertTrue("scope start not targeted by the local variable", Arrays.asList(start.getTargeters()).contains(lv));
+        assertTrue("scope end not targeted by the local variable", Arrays.asList(end.getTargeters()).contains(lv));
 
         // now let's remove the local variable
         mg.removeLocalVariable(lv);
 
-        Assert.assertFalse("scope start still targeted by the removed variable", Arrays.asList(start.getTargeters()).contains(lv));
-        Assert.assertFalse("scope end still targeted by the removed variable", Arrays.asList(end.getTargeters()).contains(lv));
-        Assert.assertNull("scope start", lv.getStart());
-        Assert.assertNull("scope end", lv.getEnd());
+        assertFalse("scope start still targeted by the removed variable", Arrays.asList(start.getTargeters()).contains(lv));
+        assertFalse("scope end still targeted by the removed variable", Arrays.asList(end.getTargeters()).contains(lv));
+        assertNull("scope start", lv.getStart());
+        assertNull("scope end", lv.getEnd());
     }
 
     @Test
@@ -103,21 +109,21 @@ public class MethodGenTestCase {
         final MethodGen mg = getMethod(Foo.class, "bar");
 
         final LocalVariableGen lv = mg.getLocalVariables()[1];
-        Assert.assertEquals("variable name", "a", lv.getName());
+        assertEquals("variable name", "a", lv.getName());
         final InstructionHandle start = lv.getStart();
         final InstructionHandle end = lv.getEnd();
-        Assert.assertNotNull("scope start", start);
-        Assert.assertNotNull("scope end", end);
-        Assert.assertTrue("scope start not targeted by the local variable", Arrays.asList(start.getTargeters()).contains(lv));
-        Assert.assertTrue("scope end not targeted by the local variable", Arrays.asList(end.getTargeters()).contains(lv));
+        assertNotNull("scope start", start);
+        assertNotNull("scope end", end);
+        assertTrue("scope start not targeted by the local variable", Arrays.asList(start.getTargeters()).contains(lv));
+        assertTrue("scope end not targeted by the local variable", Arrays.asList(end.getTargeters()).contains(lv));
 
         // now let's remove the local variables
         mg.removeLocalVariables();
 
-        Assert.assertFalse("scope start still targeted by the removed variable", Arrays.asList(start.getTargeters()).contains(lv));
-        Assert.assertFalse("scope end still targeted by the removed variable", Arrays.asList(end.getTargeters()).contains(lv));
-        Assert.assertNull("scope start", lv.getStart());
-        Assert.assertNull("scope end", lv.getEnd());
+        assertFalse("scope start still targeted by the removed variable", Arrays.asList(start.getTargeters()).contains(lv));
+        assertFalse("scope end still targeted by the removed variable", Arrays.asList(end.getTargeters()).contains(lv));
+        assertNull("scope start", lv.getStart());
+        assertNull("scope end", lv.getEnd());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
@@ -23,16 +23,17 @@ import java.util.List;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.mail.internet.MailDateFormat;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MethodGenTestCase {
 
@@ -77,9 +78,9 @@ public class MethodGenTestCase {
         final ClassGen cg = new ClassGen(jc);
         final MethodGen mg = new MethodGen(cg.getMethodAt(0), cg.getClassName(), cg.getConstantPool());
         final List<AnnotationEntryGen> firstParamAnnotations = mg.getAnnotationsOnParameter(0);
-        assertEquals("Wrong number of annotations in the first parameter", 1, firstParamAnnotations.size());
+        assertEquals(1, firstParamAnnotations.size(), "Wrong number of annotations in the first parameter");
         final List<AnnotationEntryGen> secondParamAnnotations = mg.getAnnotationsOnParameter(1);
-        assertEquals("Wrong number of annotations in the second parameter", 1, secondParamAnnotations.size());
+        assertEquals(1, secondParamAnnotations.size(), "Wrong number of annotations in the second parameter");
     }
 
     @Test
@@ -87,21 +88,21 @@ public class MethodGenTestCase {
         final MethodGen mg = getMethod(Foo.class, "bar");
 
         final LocalVariableGen lv = mg.getLocalVariables()[1];
-        assertEquals("variable name", "a", lv.getName());
+        assertEquals("a", lv.getName(), "variable name");
         final InstructionHandle start = lv.getStart();
         final InstructionHandle end = lv.getEnd();
-        assertNotNull("scope start", start);
-        assertNotNull("scope end", end);
-        assertTrue("scope start not targeted by the local variable", Arrays.asList(start.getTargeters()).contains(lv));
-        assertTrue("scope end not targeted by the local variable", Arrays.asList(end.getTargeters()).contains(lv));
+        assertNotNull(start, "scope start");
+        assertNotNull(end, "scope end");
+        assertTrue(Arrays.asList(start.getTargeters()).contains(lv), "scope start not targeted by the local variable");
+        assertTrue(Arrays.asList(end.getTargeters()).contains(lv), "scope end not targeted by the local variable");
 
         // now let's remove the local variable
         mg.removeLocalVariable(lv);
 
-        assertFalse("scope start still targeted by the removed variable", Arrays.asList(start.getTargeters()).contains(lv));
-        assertFalse("scope end still targeted by the removed variable", Arrays.asList(end.getTargeters()).contains(lv));
-        assertNull("scope start", lv.getStart());
-        assertNull("scope end", lv.getEnd());
+        assertFalse(Arrays.asList(start.getTargeters()).contains(lv), "scope start still targeted by the removed variable");
+        assertFalse(Arrays.asList(end.getTargeters()).contains(lv), "scope end still targeted by the removed variable");
+        assertNull(lv.getStart(), "scope start");
+        assertNull(lv.getEnd(), "scope end");
     }
 
     @Test
@@ -109,26 +110,26 @@ public class MethodGenTestCase {
         final MethodGen mg = getMethod(Foo.class, "bar");
 
         final LocalVariableGen lv = mg.getLocalVariables()[1];
-        assertEquals("variable name", "a", lv.getName());
+        assertEquals("a", lv.getName(), "variable name");
         final InstructionHandle start = lv.getStart();
         final InstructionHandle end = lv.getEnd();
-        assertNotNull("scope start", start);
-        assertNotNull("scope end", end);
-        assertTrue("scope start not targeted by the local variable", Arrays.asList(start.getTargeters()).contains(lv));
-        assertTrue("scope end not targeted by the local variable", Arrays.asList(end.getTargeters()).contains(lv));
+        assertNotNull(start, "scope start");
+        assertNotNull(end, "scope end");
+        assertTrue(Arrays.asList(start.getTargeters()).contains(lv), "scope start not targeted by the local variable");
+        assertTrue(Arrays.asList(end.getTargeters()).contains(lv), "scope end not targeted by the local variable");
 
         // now let's remove the local variables
         mg.removeLocalVariables();
 
-        assertFalse("scope start still targeted by the removed variable", Arrays.asList(start.getTargeters()).contains(lv));
-        assertFalse("scope end still targeted by the removed variable", Arrays.asList(end.getTargeters()).contains(lv));
-        assertNull("scope start", lv.getStart());
-        assertNull("scope end", lv.getEnd());
+        assertFalse(Arrays.asList(start.getTargeters()).contains(lv), "scope start still targeted by the removed variable");
+        assertFalse(Arrays.asList(end.getTargeters()).contains(lv), "scope end still targeted by the removed variable");
+        assertNull(lv.getStart(), "scope start");
+        assertNull(lv.getEnd(), "scope end");
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testInvalidNullMethodBody_MailDateFormat() throws Exception {
-        testInvalidNullMethodBody("javax.mail.internet.MailDateFormat");
+    @Test
+    public void testInvalidNullMethodBody_MailDateFormat() {
+        assertThrows(IllegalStateException.class, () -> testInvalidNullMethodBody("javax.mail.internet.MailDateFormat"));
     }
 
     @Test

--- a/src/test/java/org/apache/bcel/generic/TypeTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/TypeTestCase.java
@@ -17,9 +17,9 @@
  */
 package org.apache.bcel.generic;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TypeTestCase {
     @Test
@@ -30,7 +30,7 @@ public class TypeTestCase {
         // not understand generics so we need to substitute the modified value below.
         final String expectedValue = "Ljava/util/Map<X, java/util/List<Y>>;";
         final String actualValue = (Type.getType("Ljava/util/Map<TX;Ljava/util/List<TY;>;>;")).getSignature();
-        assertEquals("Type.getType", expectedValue, actualValue);
+        assertEquals(expectedValue, actualValue, "Type.getType");
     }
 
 }

--- a/src/test/java/org/apache/bcel/generic/TypeTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/TypeTestCase.java
@@ -17,9 +17,12 @@
  */
 package org.apache.bcel.generic;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class TypeTestCase extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class TypeTestCase {
+    @Test
     public void testBCEL243() {
         // expectedValue = "Ljava/util/Map<TX;Ljava/util/List<TY;>;>;";
         // The line commented out above is the correct expected value; however,

--- a/src/test/java/org/apache/bcel/util/BCELifierTestCase.java
+++ b/src/test/java/org/apache/bcel/util/BCELifierTestCase.java
@@ -24,10 +24,10 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 
 public class BCELifierTestCase {

--- a/src/test/java/org/apache/bcel/util/BCELifierTestCase.java
+++ b/src/test/java/org/apache/bcel/util/BCELifierTestCase.java
@@ -17,8 +17,6 @@
  */
 package org.apache.bcel.util;
 
-import static org.junit.Assert.*;
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -27,6 +25,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.bcel.classfile.JavaClass;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 
 public class BCELifierTestCase {

--- a/src/test/java/org/apache/bcel/util/Class2HTMLTestCase.java
+++ b/src/test/java/org/apache/bcel/util/Class2HTMLTestCase.java
@@ -21,9 +21,9 @@ import java.io.File;
 import java.io.FileInputStream;
 
 import org.apache.bcel.classfile.ClassParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Class2HTMLTestCase {
 

--- a/src/test/java/org/apache/bcel/util/Class2HTMLTestCase.java
+++ b/src/test/java/org/apache/bcel/util/Class2HTMLTestCase.java
@@ -21,17 +21,17 @@ import java.io.File;
 import java.io.FileInputStream;
 
 import org.apache.bcel.classfile.ClassParser;
-import org.junit.Assert;
 import org.junit.Test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
 
-public class Class2HTMLTestCase extends TestCase {
+public class Class2HTMLTestCase {
 
+    @Test
     public void testConvertJavaUtil() throws Exception {
         final File outputDir = new File("target/test-output/html");
         if (!outputDir.mkdirs()) { // either was not created or already existed
-            Assert.assertTrue(outputDir.isDirectory()); // fail if missing
+            assertTrue(outputDir.isDirectory()); // fail if missing
         }
 
         try (FileInputStream file = new FileInputStream("target/test-classes/Java8Example.class")) {

--- a/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
@@ -20,11 +20,12 @@ package org.apache.bcel.util;
 import java.io.IOException;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link ClassPathRepository}, {@link MemorySensitiveClassPathRepository}, and {@link
@@ -83,35 +84,35 @@ public class ClassPathRepositoryTestCase {
         }
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void testNoClassNotFound() throws ClassNotFoundException, IOException {
+    @Test
+    public void testNoClassNotFound() throws IOException {
         try (final ClassPath classPath = new ClassPath("")) {
             final ClassPathRepository repository = new ClassPathRepository(classPath);
-            repository.loadClass("no.such.Class");
+            assertThrows(ClassNotFoundException.class, () -> repository.loadClass("no.such.Class"));
         }
     }
 
-    @Test(expected = ClassNotFoundException.class)
-    public void testClassWithoutPackage() throws ClassNotFoundException, IOException {
+    @Test
+    public void testClassWithoutPackage() throws IOException {
         try (final ClassPath classPath = new ClassPath("")) {
             final ClassPathRepository repository = new ClassPathRepository(classPath);
-            repository.loadClass("ClassXYZ");
+            assertThrows(ClassNotFoundException.class, () -> repository.loadClass("ClassXYZ"));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testEmptyInput() throws ClassNotFoundException, IOException {
+    @Test
+    public void testEmptyInput() throws IOException {
         try (final ClassPath classPath = new ClassPath("")) {
             final ClassPathRepository repository = new ClassPathRepository(classPath);
-            repository.loadClass("");
+            assertThrows(IllegalArgumentException.class, () -> repository.loadClass(""));
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullInput() throws ClassNotFoundException, IOException {
+    @Test
+    public void testNullInput() throws IOException {
         try (final ClassPath classPath = new ClassPath("")) {
             final ClassPathRepository repository = new ClassPathRepository(classPath);
-            repository.loadClass((String) null);
+            assertThrows(IllegalArgumentException.class, () -> repository.loadClass((String) null));
         }
     }
 }

--- a/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathRepositoryTestCase.java
@@ -20,8 +20,11 @@ package org.apache.bcel.util;
 import java.io.IOException;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests {@link ClassPathRepository}, {@link MemorySensitiveClassPathRepository}, and {@link
@@ -34,21 +37,21 @@ public class ClassPathRepositoryTestCase {
     private void verifyCaching(final AbstractClassPathRepository repository) throws ClassNotFoundException {
         // Tests loadClass()
         final JavaClass class1 = repository.loadClass("java.lang.String");
-        Assert.assertNotNull(class1);
+        assertNotNull(class1);
         final JavaClass class2 = repository.loadClass("java/lang/Long"); // Slashes should work
-        Assert.assertNotNull(class2);
+        assertNotNull(class2);
 
         // Tests findClass()
-        Assert.assertEquals(class1, repository.findClass("java.lang.String"));
-        Assert.assertEquals(class2, repository.findClass("java.lang.Long"));
+        assertEquals(class1, repository.findClass("java.lang.String"));
+        assertEquals(class2, repository.findClass("java.lang.Long"));
 
         // Tests removeClass()
         repository.removeClass(class1);
-        Assert.assertNull(repository.findClass("java.lang.String"));
+        assertNull(repository.findClass("java.lang.String"));
 
         // Tests clear()
         repository.clear();
-        Assert.assertNull(repository.findClass("java.lang.Long"));
+        assertNull(repository.findClass("java.lang.Long"));
     }
 
     @Test
@@ -76,7 +79,7 @@ public class ClassPathRepositoryTestCase {
     public void testClassPath() throws IOException {
         try (final ClassPath classPath = new ClassPath("")) {
             final ClassPathRepository repository = new ClassPathRepository(classPath);
-            Assert.assertEquals(classPath, repository.getClassPath());
+            assertEquals(classPath, repository.getClassPath());
         }
     }
 

--- a/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
@@ -22,9 +22,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.bcel.AbstractTestCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ClassPathTestCase extends AbstractTestCase {
 

--- a/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
@@ -22,26 +22,27 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.bcel.AbstractTestCase;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 public class ClassPathTestCase extends AbstractTestCase {
 
     @Test
     public void testGetClassFile() throws IOException {
-        Assert.assertNotNull(ClassPath.SYSTEM_CLASS_PATH.getClassFile("java.lang.String"));
+        assertNotNull(ClassPath.SYSTEM_CLASS_PATH.getClassFile("java.lang.String"));
     }
 
     @Test
     public void testGetResource() {
-        Assert.assertNotNull(ClassPath.SYSTEM_CLASS_PATH.getResource("java/lang/String.class"));
+        assertNotNull(ClassPath.SYSTEM_CLASS_PATH.getResource("java/lang/String.class"));
     }
 
     @Test
     public void testGetResourceAsStream() throws IOException {
         try (final InputStream inputStream = ClassPath.SYSTEM_CLASS_PATH
                 .getResourceAsStream("java/lang/String.class")) {
-            Assert.assertNotNull(inputStream);
+            assertNotNull(inputStream);
         }
     }
 }

--- a/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ClassPathTestCase.java
@@ -23,17 +23,21 @@ import java.io.InputStream;
 
 import org.apache.bcel.AbstractTestCase;
 import org.junit.Assert;
+import org.junit.Test;
 
 public class ClassPathTestCase extends AbstractTestCase {
 
+    @Test
     public void testGetClassFile() throws IOException {
         Assert.assertNotNull(ClassPath.SYSTEM_CLASS_PATH.getClassFile("java.lang.String"));
     }
 
+    @Test
     public void testGetResource() {
         Assert.assertNotNull(ClassPath.SYSTEM_CLASS_PATH.getResource("java/lang/String.class"));
     }
 
+    @Test
     public void testGetResourceAsStream() throws IOException {
         try (final InputStream inputStream = ClassPath.SYSTEM_CLASS_PATH
                 .getResourceAsStream("java/lang/String.class")) {

--- a/src/test/java/org/apache/bcel/util/InstructionFinderTest.java
+++ b/src/test/java/org/apache/bcel/util/InstructionFinderTest.java
@@ -26,9 +26,13 @@ import org.apache.bcel.generic.ILOAD;
 import org.apache.bcel.generic.ISTORE;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class InstructionFinderTest extends AbstractTestCase {
 
+    @Test
     public void testSearch() {
         final InstructionList il = new InstructionList();
         il.append(new ILOAD(1));

--- a/src/test/java/org/apache/bcel/util/InstructionFinderTest.java
+++ b/src/test/java/org/apache/bcel/util/InstructionFinderTest.java
@@ -26,9 +26,9 @@ import org.apache.bcel.generic.ILOAD;
 import org.apache.bcel.generic.ISTORE;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InstructionFinderTest extends AbstractTestCase {
 

--- a/src/test/java/org/apache/bcel/util/LruCacheClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/LruCacheClassPathRepositoryTestCase.java
@@ -18,12 +18,12 @@
 package org.apache.bcel.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -36,11 +36,11 @@ public class LruCacheClassPathRepositoryTestCase {
         try (final ClassPath classPath = new ClassPath("")) {
             final LruCacheClassPathRepository repository = new LruCacheClassPathRepository(classPath, 2);
             final JavaClass class1 = repository.loadClass("java.lang.String");
-            Assert.assertNotNull(class1);
+            assertNotNull(class1);
             final JavaClass class2 = repository.loadClass("java.lang.Long");
-            Assert.assertNotNull(class2);
+            assertNotNull(class2);
             final JavaClass class3 = repository.loadClass("java.lang.Integer"); // Evicts class1
-            Assert.assertNotNull(class3);
+            assertNotNull(class3);
 
             assertNull(repository.findClass("java.lang.String"));
             final JavaClass cachedClass2 = repository.findClass("java.lang.Long");
@@ -53,12 +53,12 @@ public class LruCacheClassPathRepositoryTestCase {
         try (final ClassPath classPath = new ClassPath("")) {
             final LruCacheClassPathRepository repository = new LruCacheClassPathRepository(classPath, 2);
             final JavaClass class1 = repository.loadClass("java.lang.String");
-            Assert.assertNotNull(class1);
+            assertNotNull(class1);
             final JavaClass class2 = repository.loadClass("java.lang.Long");
-            Assert.assertNotNull(class2);
+            assertNotNull(class2);
             repository.findClass("java.lang.String"); // Uses class1
             final JavaClass class3 = repository.loadClass("java.lang.Integer"); // Evicts class2
-            Assert.assertNotNull(class3);
+            assertNotNull(class3);
 
             assertNull(repository.findClass("java.lang.Long"));
             final JavaClass cachedClass1 = repository.findClass("java.lang.String");

--- a/src/test/java/org/apache/bcel/util/LruCacheClassPathRepositoryTestCase.java
+++ b/src/test/java/org/apache/bcel/util/LruCacheClassPathRepositoryTestCase.java
@@ -17,14 +17,15 @@
  */
 package org.apache.bcel.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 
 import org.apache.bcel.classfile.JavaClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link LruCacheClassPathRepository}.
@@ -66,10 +67,10 @@ public class LruCacheClassPathRepositoryTestCase {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testZeroCacheSize() throws IOException {
         try (final ClassPath classPath = new ClassPath("")) {
-            new LruCacheClassPathRepository(classPath, 0);
+            assertThrows(IllegalArgumentException.class, () -> new LruCacheClassPathRepository(classPath, 0));
         }
     }
 }

--- a/src/test/java/org/apache/bcel/util/ModularRuntimeImageTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ModularRuntimeImageTestCase.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.apache.bcel.generic.JdkGenericDumpTestCase;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -34,6 +33,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Tests {@link ModularRuntimeImage}.
@@ -51,7 +51,7 @@ public class ModularRuntimeImageTestCase {
 
     public ModularRuntimeImageTestCase(final String javaHome) throws IOException {
         this.javaHome = javaHome;
-        Assume.assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
+        assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
         this.modularRuntimeImage = new ModularRuntimeImage(javaHome);
     }
 

--- a/src/test/java/org/apache/bcel/util/ModularRuntimeImageTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ModularRuntimeImageTestCase.java
@@ -20,65 +20,56 @@ package org.apache.bcel.util;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.List;
 
-import org.apache.bcel.generic.JdkGenericDumpTestCase;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests {@link ModularRuntimeImage}.
  */
-@RunWith(Parameterized.class)
 public class ModularRuntimeImageTestCase {
 
-    @Parameters(name = "{0}")
-    public static Collection<String> data() {
-        return JdkGenericDumpTestCase.data();
-    }
-
-    private final String javaHome;
-    private final ModularRuntimeImage modularRuntimeImage;
-
-    public ModularRuntimeImageTestCase(final String javaHome) throws IOException {
-        this.javaHome = javaHome;
+    @BeforeAll
+    public static void before() {
         assumeTrue(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
-        this.modularRuntimeImage = new ModularRuntimeImage(javaHome);
     }
 
-    @Test
-    public void testListJreModules() throws IOException {
+    @ParameterizedTest
+    @MethodSource("org.apache.bcel.generic.JdkGenericDumpTestCase#findJavaHomes")
+    public void testListJreModules(ModularRuntimeImage modularRuntimeImage) throws IOException {
         final List<Path> listEntries = modularRuntimeImage.list(ModularRuntimeImage.MODULES_PATH);
         assertFalse(listEntries.isEmpty());
         assertTrue(listEntries.toString().indexOf("/java.base") > -1);
     }
 
-    @Test
-    public void testListJreModule() throws IOException {
+    @ParameterizedTest
+    @MethodSource("org.apache.bcel.generic.JdkGenericDumpTestCase#findJavaHomes")
+    public void testListJreModule(ModularRuntimeImage modularRuntimeImage) throws IOException {
         final List<Path> listEntries = modularRuntimeImage.list(ModularRuntimeImage.MODULES_PATH + "/java.base");
         assertFalse(listEntries.isEmpty());
         assertTrue(listEntries.toString().indexOf("/java.base") > -1);
     }
 
-    @Test
-    public void testListJreModulePackageDir() throws IOException {
+    @ParameterizedTest
+    @MethodSource("org.apache.bcel.generic.JdkGenericDumpTestCase#findJavaHomes")
+    public void testListJreModulePackageDir(ModularRuntimeImage modularRuntimeImage) throws IOException {
         final List<Path> listEntries = modularRuntimeImage
                 .list(ModularRuntimeImage.MODULES_PATH + "/java.base/java/lang");
         assertFalse(listEntries.isEmpty());
         assertTrue(listEntries.toString().indexOf("/java.base/java/lang/String.class") > -1);
     }
 
-    @Test
-    public void testListJrePackages() throws IOException {
+    @ParameterizedTest
+    @MethodSource("org.apache.bcel.generic.JdkGenericDumpTestCase#findJavaHomes")
+    public void testListJrePackages(ModularRuntimeImage modularRuntimeImage) throws IOException {
         final List<Path> listEntries = modularRuntimeImage.list(ModularRuntimeImage.PACKAGES_PATH);
         assertFalse(listEntries.isEmpty());
         assertTrue(listEntries.toString().indexOf("java.lang") > -1);

--- a/src/test/java/org/apache/bcel/util/ModularRuntimeImageTestCase.java
+++ b/src/test/java/org/apache/bcel/util/ModularRuntimeImageTestCase.java
@@ -26,12 +26,14 @@ import java.util.List;
 import org.apache.bcel.generic.JdkGenericDumpTestCase;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link ModularRuntimeImage}.
@@ -56,29 +58,29 @@ public class ModularRuntimeImageTestCase {
     @Test
     public void testListJreModules() throws IOException {
         final List<Path> listEntries = modularRuntimeImage.list(ModularRuntimeImage.MODULES_PATH);
-        Assert.assertFalse(listEntries.isEmpty());
-        Assert.assertTrue(listEntries.toString().indexOf("/java.base") > -1);
+        assertFalse(listEntries.isEmpty());
+        assertTrue(listEntries.toString().indexOf("/java.base") > -1);
     }
 
     @Test
     public void testListJreModule() throws IOException {
         final List<Path> listEntries = modularRuntimeImage.list(ModularRuntimeImage.MODULES_PATH + "/java.base");
-        Assert.assertFalse(listEntries.isEmpty());
-        Assert.assertTrue(listEntries.toString().indexOf("/java.base") > -1);
+        assertFalse(listEntries.isEmpty());
+        assertTrue(listEntries.toString().indexOf("/java.base") > -1);
     }
 
     @Test
     public void testListJreModulePackageDir() throws IOException {
         final List<Path> listEntries = modularRuntimeImage
                 .list(ModularRuntimeImage.MODULES_PATH + "/java.base/java/lang");
-        Assert.assertFalse(listEntries.isEmpty());
-        Assert.assertTrue(listEntries.toString().indexOf("/java.base/java/lang/String.class") > -1);
+        assertFalse(listEntries.isEmpty());
+        assertTrue(listEntries.toString().indexOf("/java.base/java/lang/String.class") > -1);
     }
 
     @Test
     public void testListJrePackages() throws IOException {
         final List<Path> listEntries = modularRuntimeImage.list(ModularRuntimeImage.PACKAGES_PATH);
-        Assert.assertFalse(listEntries.isEmpty());
-        Assert.assertTrue(listEntries.toString().indexOf("java.lang") > -1);
+        assertFalse(listEntries.isEmpty());
+        assertTrue(listEntries.toString().indexOf("java.lang") > -1);
     }
 }

--- a/src/test/java/org/apache/bcel/verifier/AbstractVerifierTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/AbstractVerifierTestCase.java
@@ -21,9 +21,11 @@ package org.apache.bcel.verifier;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public abstract class AbstractVerifierTestCase extends TestCase {
+public abstract class AbstractVerifierTestCase {
 
     public static final String TEST_PACKAGE = AbstractVerifierTestCase.class.getPackage().getName() + ".tests.";
 

--- a/src/test/java/org/apache/bcel/verifier/AbstractVerifierTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/AbstractVerifierTestCase.java
@@ -21,9 +21,9 @@ package org.apache.bcel.verifier;
 import org.apache.bcel.Repository;
 import org.apache.bcel.classfile.JavaClass;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractVerifierTestCase {
 
@@ -37,7 +37,7 @@ public abstract class AbstractVerifierTestCase {
      */
     public void assertVerifyOK(final String classname, final String message) {
         final String testClassname = TEST_PACKAGE + classname;
-        assertTrue(message, doAllPasses(testClassname));
+        assertTrue(doAllPasses(testClassname), message);
     }
 
     /**
@@ -49,7 +49,7 @@ public abstract class AbstractVerifierTestCase {
      */
     public void assertVerifyRejected(final String classname, final String message) {
         final String testClassname = TEST_PACKAGE + classname;
-        assertFalse(message, doAllPasses(testClassname));
+        assertFalse(doAllPasses(testClassname), message);
     }
 
     /**

--- a/src/test/java/org/apache/bcel/verifier/JiraBcel291TestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/JiraBcel291TestCase.java
@@ -18,10 +18,10 @@
 
 package org.apache.bcel.verifier;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore
+@Disabled
 public class JiraBcel291TestCase {
 
     @Test

--- a/src/test/java/org/apache/bcel/verifier/VerifierArrayAccessTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierArrayAccessTestCase.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import org.apache.bcel.verifier.tests.TestArrayAccess02Creator;
 import org.apache.bcel.verifier.tests.TestArrayAccess03Creator;
 import org.apache.bcel.verifier.tests.TestArrayAccess04Creator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VerifierArrayAccessTestCase extends AbstractVerifierTestCase {
 

--- a/src/test/java/org/apache/bcel/verifier/VerifierArrayAccessTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierArrayAccessTestCase.java
@@ -23,9 +23,11 @@ import java.io.IOException;
 import org.apache.bcel.verifier.tests.TestArrayAccess02Creator;
 import org.apache.bcel.verifier.tests.TestArrayAccess03Creator;
 import org.apache.bcel.verifier.tests.TestArrayAccess04Creator;
+import org.junit.Test;
 
 public class VerifierArrayAccessTestCase extends AbstractVerifierTestCase {
 
+    @Test
     public void testInvalidArrayAccess() throws IOException {
         new TestArrayAccess03Creator().create();
         assertVerifyRejected("TestArrayAccess03", "Verification of an arraystore instruction on an object must fail.");
@@ -34,6 +36,7 @@ public class VerifierArrayAccessTestCase extends AbstractVerifierTestCase {
                 "Verification of an arraystore instruction of an int on an array of references must fail.");
     }
 
+    @Test
     public void testValidArrayAccess() throws IOException {
         assertVerifyOK("TestArrayAccess01",
                 "Verification of an arraystore instruction on an array that is not compatible with the stored element must pass.");

--- a/src/test/java/org/apache/bcel/verifier/VerifierInvokeTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierInvokeTestCase.java
@@ -18,22 +18,27 @@
 
 package org.apache.bcel.verifier;
 
+import org.junit.Test;
 
 public class VerifierInvokeTestCase extends AbstractVerifierTestCase {
 
+    @Test
     public void testLegalInvokeVirtual() {
         assertVerifyOK("TestLegalInvokeVirtual01", "Verification of invokevirtual on method defined in superclass must pass.");
         assertVerifyOK("TestLegalInvokeVirtual02", "Verification of invokevirtual on method defined in superinterface must pass.");
     }
 
+    @Test
     public void testLegalInvokeStatic() {
         assertVerifyOK("TestLegalInvokeStatic01", "Verification of invokestatic on method defined in superclass must pass.");
     }
 
+    @Test
     public void testLegalInvokeInterface() {
         assertVerifyOK("TestLegalInvokeInterface01", "Verification of invokeinterface on method defined in superinterface must pass.");
     }
 
+    @Test
     public void testLegalInvokeSpecial() {
         assertVerifyOK("TestLegalInvokeSpecial01", "Verification of invokespecial on method defined in superclass must pass.");
         assertVerifyOK("TestLegalInvokeSpecial02", "Verification of invokespecial on method defined in superclass must pass.");

--- a/src/test/java/org/apache/bcel/verifier/VerifierInvokeTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierInvokeTestCase.java
@@ -18,7 +18,7 @@
 
 package org.apache.bcel.verifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VerifierInvokeTestCase extends AbstractVerifierTestCase {
 

--- a/src/test/java/org/apache/bcel/verifier/VerifierReturnTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierReturnTestCase.java
@@ -21,9 +21,11 @@ import java.io.IOException;
 
 import org.apache.bcel.verifier.tests.TestReturn01Creator;
 import org.apache.bcel.verifier.tests.TestReturn03Creator;
+import org.junit.Test;
 
 public class VerifierReturnTestCase extends AbstractVerifierTestCase {
 
+    @Test
     public void testInvalidReturn() throws IOException {
         new TestReturn01Creator().create();
         assertVerifyRejected("TestReturn01", "Verification of a void method that returns an object must fail.");
@@ -31,6 +33,7 @@ public class VerifierReturnTestCase extends AbstractVerifierTestCase {
         assertVerifyRejected("TestReturn03", "Verification of an int method that returns null must fail.");
     }
 
+    @Test
     public void testValidReturn() {
         assertVerifyOK("TestReturn02", "Verification of a method that returns a newly created object must pass.");
         assertVerifyOK("TestArray01", "Verification of a method that returns an array must pass.");

--- a/src/test/java/org/apache/bcel/verifier/VerifierReturnTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierReturnTestCase.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 
 import org.apache.bcel.verifier.tests.TestReturn01Creator;
 import org.apache.bcel.verifier.tests.TestReturn03Creator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VerifierReturnTestCase extends AbstractVerifierTestCase {
 

--- a/src/test/java/org/apache/bcel/verifier/VerifierTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierTestCase.java
@@ -18,11 +18,11 @@
 
 package org.apache.bcel.verifier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class VerifierTestCase {
 
@@ -33,12 +33,12 @@ public class VerifierTestCase {
         final Verifier verifier = VerifierFactory.getVerifier(classname);
         VerificationResult result = verifier.doPass1();
 
-        assertEquals("Pass 1 verification of " + classname + " failed: " + result.getMessage(), VerificationResult.VERIFIED_OK,
-                result.getStatus());
+        assertEquals(VerificationResult.VERIFIED_OK, result.getStatus(),
+                "Pass 1 verification of " + classname + " failed: " + result.getMessage());
 
         result = verifier.doPass2();
 
-        assertEquals("Pass 2 verification of " + classname + " failed: " + result.getMessage(), VerificationResult.VERIFIED_OK,
-                result.getStatus());
+        assertEquals(VerificationResult.VERIFIED_OK, result.getStatus(),
+                "Pass 2 verification of " + classname + " failed: " + result.getMessage());
     }
 }

--- a/src/test/java/org/apache/bcel/verifier/VerifierTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierTestCase.java
@@ -18,12 +18,15 @@
 
 package org.apache.bcel.verifier;
 
+import org.junit.Test;
+
 import java.util.Collection;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class VerifierTestCase extends TestCase {
+public class VerifierTestCase {
 
+    @Test
     public void testDefaultMethodValidation() {
         final String classname = Collection.class.getName();
 

--- a/src/test/java/org/apache/bcel/verifier/statics/Pass2VerifierTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/statics/Pass2VerifierTestCase.java
@@ -17,7 +17,7 @@
 
 package org.apache.bcel.verifier.statics;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Pass2VerifierTestCase {
 

--- a/src/test/java/org/apache/bcel/verifier/structurals/UninitializedObjectTypeTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/structurals/UninitializedObjectTypeTestCase.java
@@ -17,7 +17,7 @@
 
 package org.apache.bcel.verifier.structurals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class UninitializedObjectTypeTestCase {
 

--- a/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess02Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess02Creator.java
@@ -32,7 +32,7 @@ import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.PUSH;
 import org.apache.bcel.generic.Type;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestArrayAccess02Creator extends TestCreator {
   private final InstructionFactory _factory;

--- a/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess02Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess02Creator.java
@@ -31,7 +31,8 @@ import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.PUSH;
 import org.apache.bcel.generic.Type;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertNotNull;
 
 public class TestArrayAccess02Creator extends TestCreator {
   private final InstructionFactory _factory;
@@ -59,10 +60,10 @@ public void create(final OutputStream out) throws IOException {
             TEST_PACKAGE+".TestArrayAccess02", il, _cp);
 
     final InstructionHandle ih_0 = il.append(InstructionFactory.createLoad(Type.OBJECT, 0));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createInvoke("java.lang.Object", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     final InstructionHandle ih_4 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_4); // TODO why is this not used
+    assertNotNull(ih_4); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());
@@ -75,22 +76,22 @@ public void create(final OutputStream out) throws IOException {
             "test", TEST_PACKAGE+".TestArrayAccess02", il, _cp);
 
     final InstructionHandle ih_0 = il.append(new PUSH(_cp, 1));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createNewArray(new ObjectType(TEST_PACKAGE+".TestArrayAccess02"), (short) 1));
     il.append(InstructionFactory.createStore(Type.OBJECT, 0));
     final InstructionHandle ih_5 = il.append(new PUSH(_cp, 1));
-    Assert.assertNotNull(ih_5); // TODO why is this not used
+    assertNotNull(ih_5); // TODO why is this not used
     il.append(_factory.createNewArray(Type.STRING, (short) 1));
     il.append(InstructionFactory.createStore(Type.OBJECT, 1));
     final InstructionHandle ih_10 = il.append(InstructionFactory.createLoad(Type.OBJECT, 1));
-    Assert.assertNotNull(ih_10); // TODO why is this not used
+    assertNotNull(ih_10); // TODO why is this not used
     il.append(new PUSH(_cp, 0));
     il.append(_factory.createNew(TEST_PACKAGE+".TestArrayAccess02"));
     il.append(InstructionConst.DUP);
     il.append(_factory.createInvoke(TEST_PACKAGE+".TestArrayAccess02", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     il.append(InstructionConst.AASTORE);
     final InstructionHandle ih_20 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_20); // TODO why is this not used
+    assertNotNull(ih_20); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());

--- a/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess03Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess03Creator.java
@@ -32,7 +32,7 @@ import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.PUSH;
 import org.apache.bcel.generic.Type;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestArrayAccess03Creator extends TestCreator {
   private final InstructionFactory _factory;

--- a/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess03Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess03Creator.java
@@ -31,7 +31,8 @@ import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.PUSH;
 import org.apache.bcel.generic.Type;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertNotNull;
 
 public class TestArrayAccess03Creator extends TestCreator {
   private final InstructionFactory _factory;
@@ -59,10 +60,10 @@ public void create(final OutputStream out) throws IOException {
             TEST_PACKAGE+".TestArrayAccess03", il, _cp);
 
     final InstructionHandle ih_0 = il.append(InstructionFactory.createLoad(Type.OBJECT, 0));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createInvoke("java.lang.Object", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     final InstructionHandle ih_4 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_4); // TODO why is this not used
+    assertNotNull(ih_4); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());
@@ -75,18 +76,18 @@ public void create(final OutputStream out) throws IOException {
             new String[] { "arg0" }, "test", TEST_PACKAGE+".TestArrayAccess03", il, _cp);
 
     final InstructionHandle ih_0 = il.append(new PUSH(_cp, 1));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createNewArray(new ObjectType(TEST_PACKAGE+".TestArrayAccess03"), (short) 1));
     il.append(InstructionFactory.createStore(Type.OBJECT, 1));
     final InstructionHandle ih_5 = il.append(InstructionFactory.createLoad(Type.OBJECT, 0));
-    Assert.assertNotNull(ih_5); // TODO why is this not used
+    assertNotNull(ih_5); // TODO why is this not used
     il.append(new PUSH(_cp, 0));
     il.append(_factory.createNew(TEST_PACKAGE+".TestArrayAccess03"));
     il.append(InstructionConst.DUP);
     il.append(_factory.createInvoke(TEST_PACKAGE+".TestArrayAccess03", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     il.append(InstructionConst.AASTORE);
     final InstructionHandle ih_15 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_15); // TODO why is this not used
+    assertNotNull(ih_15); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());

--- a/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess04Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess04Creator.java
@@ -32,7 +32,7 @@ import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.PUSH;
 import org.apache.bcel.generic.Type;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestArrayAccess04Creator extends TestCreator {
   private final InstructionFactory _factory;

--- a/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess04Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestArrayAccess04Creator.java
@@ -31,7 +31,8 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.PUSH;
 import org.apache.bcel.generic.Type;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertNotNull;
 
 public class TestArrayAccess04Creator extends TestCreator {
   private final InstructionFactory _factory;
@@ -59,10 +60,10 @@ public void create(final OutputStream out) throws IOException {
             TEST_PACKAGE+".TestArrayAccess04", il, _cp);
 
     final InstructionHandle ih_0 = il.append(InstructionFactory.createLoad(Type.OBJECT, 0));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createInvoke("java.lang.Object", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     final InstructionHandle ih_4 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_4); // TODO why is this not used
+    assertNotNull(ih_4); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());
@@ -75,19 +76,19 @@ public void create(final OutputStream out) throws IOException {
             new String[] { "arg0" }, "test", TEST_PACKAGE+".TestArrayAccess04", il, _cp);
 
     final InstructionHandle ih_0 = il.append(new PUSH(_cp, 1));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createNewArray(Type.OBJECT, (short) 1));
     il.append(InstructionFactory.createStore(Type.OBJECT, 1));
     final InstructionHandle ih_5 = il.append(new PUSH(_cp, 1));
-    Assert.assertNotNull(ih_5); // TODO why is this not used
+    assertNotNull(ih_5); // TODO why is this not used
     il.append(InstructionFactory.createStore(Type.INT, 2));
     final InstructionHandle ih_7 = il.append(InstructionFactory.createLoad(Type.OBJECT, 1));
-    Assert.assertNotNull(ih_7); // TODO why is this not used
+    assertNotNull(ih_7); // TODO why is this not used
     il.append(new PUSH(_cp, 0));
     il.append(InstructionFactory.createLoad(Type.INT, 2));
     il.append(InstructionConst.AASTORE);
     final InstructionHandle ih_11 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_11); // TODO why is this not used
+    assertNotNull(ih_11); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());

--- a/src/test/java/org/apache/bcel/verifier/tests/TestReturn01Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestReturn01Creator.java
@@ -30,7 +30,7 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestReturn01Creator extends TestCreator {
   private final InstructionFactory _factory;

--- a/src/test/java/org/apache/bcel/verifier/tests/TestReturn01Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestReturn01Creator.java
@@ -29,7 +29,8 @@ import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertNotNull;
 
 public class TestReturn01Creator extends TestCreator {
   private final InstructionFactory _factory;
@@ -57,10 +58,10 @@ public void create(final OutputStream out) throws IOException {
             "<init>", TEST_PACKAGE+".TestReturn01", il, _cp);
 
     final InstructionHandle ih_0 = il.append(InstructionFactory.createLoad(Type.OBJECT, 0));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createInvoke("java.lang.Object", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     final InstructionHandle ih_4 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_4); // TODO why is this not used
+    assertNotNull(ih_4); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());
@@ -73,12 +74,12 @@ public void create(final OutputStream out) throws IOException {
             new String[] {  }, "foo", TEST_PACKAGE+".TestReturn01", il, _cp);
 
     final InstructionHandle ih_0 = il.append(_factory.createNew("java.lang.Object"));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(InstructionConst.DUP);
     il.append(_factory.createInvoke("java.lang.Object", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     il.append(InstructionConst.NOP);
     final InstructionHandle ih_8 = il.append(InstructionFactory.createReturn(Type.OBJECT));
-    Assert.assertNotNull(ih_8); // TODO why is this not used
+    assertNotNull(ih_8); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());

--- a/src/test/java/org/apache/bcel/verifier/tests/TestReturn03Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestReturn03Creator.java
@@ -30,7 +30,7 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TestReturn03Creator extends TestCreator {
   private final InstructionFactory _factory;

--- a/src/test/java/org/apache/bcel/verifier/tests/TestReturn03Creator.java
+++ b/src/test/java/org/apache/bcel/verifier/tests/TestReturn03Creator.java
@@ -29,7 +29,8 @@ import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
-import org.junit.Assert;
+
+import static org.junit.Assert.assertNotNull;
 
 public class TestReturn03Creator extends TestCreator {
   private final InstructionFactory _factory;
@@ -57,10 +58,10 @@ public void create(final OutputStream out) throws IOException {
             "<init>", TEST_PACKAGE+".TestReturn03", il, _cp);
 
     final InstructionHandle ih_0 = il.append(InstructionFactory.createLoad(Type.OBJECT, 0));
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(_factory.createInvoke("java.lang.Object", "<init>", Type.VOID, Type.NO_ARGS, Const.INVOKESPECIAL));
     final InstructionHandle ih_4 = il.append(InstructionFactory.createReturn(Type.VOID));
-    Assert.assertNotNull(ih_4); // TODO why is this not used
+    assertNotNull(ih_4); // TODO why is this not used
     method.setMaxStack();
     method.setMaxLocals();
     _cg.addMethod(method.getMethod());
@@ -73,7 +74,7 @@ public void create(final OutputStream out) throws IOException {
             new String[] {  }, "test3", TEST_PACKAGE+".TestReturn03", il, _cp);
 
     final InstructionHandle ih_0 = il.append(InstructionConst.ACONST_NULL);
-    Assert.assertNotNull(ih_0); // TODO why is this not used
+    assertNotNull(ih_0); // TODO why is this not used
     il.append(InstructionFactory.createReturn(Type.OBJECT));
     method.setMaxStack();
     method.setMaxLocals();


### PR DESCRIPTION
This PR migrates the project to the modern JUnit Jupiter in order to make it easier to write tests for it and lower the entry bar for new contributors.

While JUnit 4 and JUnit Jupiter are similar in many ways, they are not API compatible, so some changes had to be made:

1. Dependencies
    1. The dependency on `junit.junit:4.13` was replaced by a dependency on `org.junit.jupiter:junit-jupiter`

1. Annotations
    1. `org.junit.jupiter.api.Test` was used as a drop-in replacement for `org.junit.Test` in the simple case the annotation had no arguments.
    1. `org.junit.jupiter.api.Test` was added to existing JUnit 3 style test methods (i.e., `public`, `void` methods with no arguments and a name begining in "test').
    1. `org.junit.jupiter.api.BeforeEach` was used as a drop-in replacement for `org.junit.Before`.
    1. `org.junit.jupiter.api.BeforeEach` was added to existing JUnit 3 style setUp methods (i.e., methods with the signature `public void setUp()`).
    1. `org.junit.jupiter.api.Disabled` was used as a drop-in replacement for `org.junit.Ignore`.
    1. Classes annotated with `@RunWith(Parameterized.class)` were rewritten so their test use  `org.junit.jupiter.params.ParameterizedTest`

1. Class structure
    1. `junit.framework.TestCase` was removed as a super class from the classes that extended it.

1. Assertions
    1. `org.junit.jupiter.api.Assertions`' methods were used as drop-in replacements for methods of the same name from `org.junit.Assert` in the case the method didn't use the optional message argument.
    1. `org.junit.jupiter.api.Assertions`' methods were used as replacements for methods of the same name from `org.junit.Assert` in the case the method did use the optional message argument. In this case, the message argument that was the first argument in the `Assert`'s method was moved to be the last argument in the `Assertions`' method arguments.
    1. Usages of `org.junit.Assert`'s methods via the wrappers in `junit.Framework.TestCase` were replaced with static imports of the corresponding method from `org.junit.jupiter.api.Assertiosn`, as detailed in the two previous points.
    1. `org.junit.Test` annotations with an `expected` argument were replaced by `org.junit.jupiter.api.Assertions#assertThrows` calls. As a side bonus, this change also makes the test more accurate by narrowing the scope that's expected to throw the exception and preventing false positives from situations where the wrong statement throws the expected exception.

1. Assumptions
    1. `org.junit.jupiter.api.Assumptions`' methods were used as drop-in replacements for methods of the same name from `org.junit.Assume`.

1. Miscellaneous
    1. In `org.apache.bcel.HandleTestCase`, the dependency on `junit.framework.AssertionFailedError` was removed, and instead its JDK parent, `java.lang.AssertionError`, was used.