### PR TITLE
BCEL-343 JUnit Assertion improvement

### DIFF
--- a/src/test/java/org/apache/bcel/AbstractTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractTestCase.java
@@ -35,7 +35,7 @@ import org.apache.bcel.generic.SimpleElementValueGen;
 import org.apache.bcel.util.ClassPath;
 import org.apache.bcel.util.SyntheticRepository;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class AbstractTestCase
 {
@@ -141,8 +141,7 @@ public abstract class AbstractTestCase
                 chosenAttrsList.add(element);
             }
         }
-        assertTrue(chosenAttrsList.size() == 1,
-                "Should be one match: " + chosenAttrsList.size());
+        assertEquals(1, chosenAttrsList.size(), "Wrong number of matches");
         return chosenAttrsList.get(0);
     }
 

--- a/src/test/java/org/apache/bcel/AbstractTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractTestCase.java
@@ -146,22 +146,6 @@ public abstract class AbstractTestCase
         return chosenAttrsList.get(0);
     }
 
-    protected String dumpAttributes(final Attribute[] as)
-    {
-        final StringBuilder result = new StringBuilder();
-        result.append("AttributeArray:[");
-        for (int i = 0; i < as.length; i++)
-        {
-            final Attribute attr = as[i];
-            result.append(attr.toString());
-            if (i + 1 < as.length) {
-                result.append(",");
-            }
-        }
-        result.append("]");
-        return result.toString();
-    }
-
     protected String dumpAnnotationEntries(final AnnotationEntry[] as)
     {
         final StringBuilder result = new StringBuilder();

--- a/src/test/java/org/apache/bcel/AnnotationAccessFlagTestCase.java
+++ b/src/test/java/org/apache/bcel/AnnotationAccessFlagTestCase.java
@@ -21,6 +21,7 @@ package org.apache.bcel;
 import org.apache.bcel.classfile.JavaClass;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AnnotationAccessFlagTestCase extends AbstractTestCase
@@ -37,7 +38,7 @@ public class AnnotationAccessFlagTestCase extends AbstractTestCase
         assertTrue(clazz.isAnnotation(),
                 "Expected SimpleAnnotation class to say it was an annotation - but it didn't !");
         clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleClass");
-        assertTrue(!clazz.isAnnotation(),
+        assertFalse(clazz.isAnnotation(),
                 "Expected SimpleClass class to say it was not an annotation - but it didn't !");
     }
 }

--- a/src/test/java/org/apache/bcel/AnnotationDefaultAttributeTestCase.java
+++ b/src/test/java/org/apache/bcel/AnnotationDefaultAttributeTestCase.java
@@ -25,7 +25,7 @@ import org.apache.bcel.classfile.Method;
 import org.apache.bcel.classfile.SimpleElementValue;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AnnotationDefaultAttributeTestCase extends AbstractTestCase
 {
@@ -42,9 +42,7 @@ public class AnnotationDefaultAttributeTestCase extends AbstractTestCase
         final AnnotationDefault a = (AnnotationDefault) findAttribute(
                 "AnnotationDefault", m.getAttributes());
         final SimpleElementValue val = (SimpleElementValue) a.getDefaultValue();
-        assertTrue(val.getElementValueType() == ElementValue.STRING,
-                "Should be STRING but is " + val.getElementValueType());
-        assertTrue(val.getValueString().equals("bananas"),
-                "Should have default of bananas but default is " + val.getValueString());
+        assertEquals(ElementValue.STRING, val.getElementValueType(), "Wrong element value type");
+        assertEquals("bananas", val.getValueString(), "Wrong default");
     }
 }

--- a/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
+++ b/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
@@ -33,6 +33,7 @@ import org.apache.bcel.generic.ObjectType;
 import org.apache.bcel.generic.SimpleElementValueGen;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -56,9 +57,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
                 ElementValueGen.PRIMITIVE_INT, cp, 555);
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue(evg.getIndex() == cp.lookupInteger(555),
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + cp.lookupInteger(555));
+        assertEquals(cp.lookupInteger(555), evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -71,9 +70,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
                 ElementValueGen.PRIMITIVE_FLOAT, cp, 111.222f);
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue(evg.getIndex() == cp.lookupFloat(111.222f),
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + cp.lookupFloat(111.222f));
+        assertEquals(cp.lookupFloat(111.222f), evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -87,9 +84,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupDouble(333.44);
-        assertTrue(evg.getIndex() == idx,
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx);
+        assertEquals(idx, evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -103,9 +98,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupLong(3334455L);
-        assertTrue(evg.getIndex() == idx,
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx);
+        assertEquals(idx, evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -119,9 +112,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger('t');
-        assertTrue(evg.getIndex() == idx,
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx);
+        assertEquals(idx, evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -135,9 +126,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger((byte) 'z');
-        assertTrue(evg.getIndex() == idx,
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx);
+        assertEquals(idx, evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -151,9 +140,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger(1); // 1 == true
-        assertTrue(evg.getIndex() == idx,
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx);
+        assertEquals(idx, evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -167,9 +154,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
         // Creation of an element like that should leave a new entry in the
         // cpool
         final int idx = cp.lookupInteger(42);
-        assertTrue(evg.getIndex() == idx,
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + idx);
+        assertEquals(idx, evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -185,9 +170,7 @@ public class ElementValueGenTestCase extends AbstractTestCase
                 ElementValueGen.STRING, cp, "hello");
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue(evg.getIndex() == cp.lookupUtf8("hello"),
-                "Should have the same index in the constantpool but "
-                + evg.getIndex() + "!=" + cp.lookupUtf8("hello"));
+        assertEquals(cp.lookupUtf8("hello"), evg.getIndex(), "Should have the same index in the constantpool");
         checkSerialize(evg, cp);
     }
 
@@ -203,9 +186,8 @@ public class ElementValueGenTestCase extends AbstractTestCase
         final EnumElementValueGen evg = new EnumElementValueGen(enumType, "Red", cp);
         // Creation of an element like that should leave a new entry in the
         // cpool
-        assertTrue(evg.getValueIndex() == cp.lookupUtf8("Red"),
-                "The new ElementValue value index should match the contents of the constantpool but "
-                        + evg.getValueIndex() + "!=" + cp.lookupUtf8("Red"));
+        assertEquals(cp.lookupUtf8("Red"), evg.getValueIndex(),
+                "The new ElementValue value index should match the contents of the constantpool");
         // BCELBUG: Should the class signature or class name be in the constant
         // pool? (see note in ConstantPool)
         // assertTrue("The new ElementValue type index should match the contents

--- a/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
+++ b/src/test/java/org/apache/bcel/ElementValueGenTestCase.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class ElementValueGenTestCase extends AbstractTestCase
 {
@@ -223,8 +222,6 @@ public class ElementValueGenTestCase extends AbstractTestCase
             evgAfter = ElementValueGen.readElementValue(dis, cpg);
         }
         final String afterValue = evgAfter.stringifyValue();
-        if (!beforeValue.equals(afterValue)) {
-            fail("Deserialization failed: before='" + beforeValue + "' after='" + afterValue + "'");
-        }
+        assertEquals(beforeValue, afterValue, "Deserialization failed");
     }
 }

--- a/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
+++ b/src/test/java/org/apache/bcel/EnclosingMethodAttributeTestCase.java
@@ -28,8 +28,8 @@ import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EnclosingMethodAttributeTestCase extends AbstractTestCase
 {
@@ -44,16 +44,12 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AttributeTestClassEM01$1S");
         final ConstantPool pool = clazz.getConstantPool();
         final Attribute[] encMethodAttrs = findAttribute("EnclosingMethod", clazz);
-        assertTrue(encMethodAttrs.length == 1,
-                "Expected 1 EnclosingMethod attribute but found " + encMethodAttrs.length);
+        assertEquals(1, encMethodAttrs.length, "Wrong number of EnclosingMethod attributes");
         final EnclosingMethod em = (EnclosingMethod) encMethodAttrs[0];
         final String enclosingClassName = em.getEnclosingClass().getBytes(pool);
         final String enclosingMethodName = em.getEnclosingMethod().getName(pool);
-        assertTrue(enclosingClassName.equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM01"),
-                "Expected class name to be '"+PACKAGE_BASE_SIG+"/data/AttributeTestClassEM01' but was "
-                        + enclosingClassName);
-        assertTrue(enclosingMethodName.equals("main"),
-                "Expected method name to be 'main' but was " + enclosingMethodName);
+        assertEquals(PACKAGE_BASE_SIG + "/data/AttributeTestClassEM01", enclosingClassName, "Wrong class name");
+        assertEquals(enclosingMethodName, "main", "Wrong method name");
     }
 
     /**
@@ -67,16 +63,12 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AttributeTestClassEM02$1");
         final ConstantPool pool = clazz.getConstantPool();
         final Attribute[] encMethodAttrs = findAttribute("EnclosingMethod", clazz);
-        assertTrue(encMethodAttrs.length == 1,
-                "Expected 1 EnclosingMethod attribute but found " + encMethodAttrs.length);
+        assertEquals(1, encMethodAttrs.length, "Expected 1 EnclosingMethod attribute but found " + encMethodAttrs.length);
         final EnclosingMethod em = (EnclosingMethod) encMethodAttrs[0];
         final String enclosingClassName = em.getEnclosingClass().getBytes(pool);
-        assertTrue(em.getEnclosingMethodIndex() == 0,
-                "The class is not within a method, so method_index should be null, but it is "
-                        + em.getEnclosingMethodIndex());
-        assertTrue(enclosingClassName.equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02"),
-                "Expected class name to be '"+PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02' but was "
-                        + enclosingClassName);
+        assertEquals(em.getEnclosingMethodIndex(), 0,
+                "The class is not within a method, so method_index should be null");
+        assertEquals(PACKAGE_BASE_SIG + "/data/AttributeTestClassEM02", enclosingClassName, "Wrong class name");
     }
 
     /**
@@ -89,8 +81,7 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.AttributeTestClassEM02$1");
         final ConstantPool pool = clazz.getConstantPool();
         final Attribute[] encMethodAttrs = findAttribute("EnclosingMethod", clazz);
-        assertTrue(encMethodAttrs.length == 1,
-                "Expected 1 EnclosingMethod attribute but found " + encMethodAttrs.length);
+        assertEquals(1, encMethodAttrs.length, "Wrong number of EnclosingMethod attributes");
         // Write it out
         final File tfile = createTestdataFile("AttributeTestClassEM02$1.class");
         clazz.dump(tfile);
@@ -100,12 +91,9 @@ public class EnclosingMethodAttributeTestCase extends AbstractTestCase
         assertNotNull(clazz2); // Use the variable to avoid a warning
         final EnclosingMethod em = (EnclosingMethod) encMethodAttrs[0];
         final String enclosingClassName = em.getEnclosingClass().getBytes(pool);
-        assertTrue(em.getEnclosingMethodIndex() == 0,
-                "The class is not within a method, so method_index should be null, but it is "
-                        + em.getEnclosingMethodIndex());
-        assertTrue(enclosingClassName.equals(PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02"),
-                "Expected class name to be '"+PACKAGE_BASE_SIG+"/data/AttributeTestClassEM02' but was "
-                        + enclosingClassName);
+        assertEquals(em.getEnclosingMethodIndex(), 0,
+                "The class is not within a method, so method_index should be null");
+        assertEquals(PACKAGE_BASE_SIG + "/data/AttributeTestClassEM02", enclosingClassName, "Wrong class name");
         tfile.deleteOnExit();
     }
 }

--- a/src/test/java/org/apache/bcel/EnumAccessFlagTestCase.java
+++ b/src/test/java/org/apache/bcel/EnumAccessFlagTestCase.java
@@ -21,6 +21,7 @@ package org.apache.bcel;
 import org.apache.bcel.classfile.JavaClass;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EnumAccessFlagTestCase extends AbstractTestCase
@@ -37,7 +38,7 @@ public class EnumAccessFlagTestCase extends AbstractTestCase
         assertTrue(clazz.isEnum(),
                 "Expected SimpleEnum class to say it was an enum - but it didn't !");
         clazz = getTestClass(PACKAGE_BASE_NAME+".data.SimpleClass");
-        assertTrue(!clazz.isEnum(),
+        assertFalse(clazz.isEnum(),
                 "Expected SimpleClass class to say it was not an enum - but it didn't !");
     }
 }

--- a/src/test/java/org/apache/bcel/PerformanceTest.java
+++ b/src/test/java/org/apache/bcel/PerformanceTest.java
@@ -20,7 +20,6 @@ package org.apache.bcel;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Enumeration;
@@ -134,7 +133,7 @@ public final class PerformanceTest {
     @Test
     public void testPerformance() {
         final File javaLib = new File(System.getProperty("java.home"), "lib");
-        javaLib.listFiles((FileFilter) file -> {
+        javaLib.listFiles(file -> {
             if(file.getName().endsWith(".jar")) {
                 try {
                     test(file);

--- a/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
@@ -80,7 +80,8 @@ public class JDKClassDumpTestCase {
             int i = 0;
             for (final int out : baos.toByteArray()) {
                 final int in = src.read();
-                assertEquals(in, out & 0xFF, name + ": Mismatch at " + i);
+                int j = i;
+                assertEquals(in, out & 0xFF, () -> (name + ": Mismatch at " + j));
                 i++;
             }
         }

--- a/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/JDKClassDumpTestCase.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.InputStream;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
@@ -40,7 +39,7 @@ public class JDKClassDumpTestCase {
     @Test
     public void testPerformance() throws Exception {
         final File javaLib = new File(System.getProperty("java.home") + "/lib");
-        javaLib.listFiles((FileFilter) file -> {
+        javaLib.listFiles(file -> {
             if (file.getName().endsWith(".jar")) {
                 try {
                     testJar(file);

--- a/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
@@ -33,6 +33,7 @@ import org.apache.bcel.classfile.RuntimeInvisibleAnnotations;
 import org.apache.bcel.classfile.RuntimeVisibleAnnotations;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -140,27 +141,13 @@ public class AnnotationGenTestCase extends AbstractTestCase
                 annAfter = AnnotationEntryGen.read(dis, cpg, a.isRuntimeVisible());
             }
             final String afterName = annAfter.getTypeName();
-            if (!beforeName.equals(afterName))
-            {
-                fail("Deserialization failed: before type='" + beforeName
-                        + "' after type='" + afterName + "'");
-            }
-            if (a.getValues().size() != annAfter.getValues().size())
-            {
-                fail("Different numbers of element name value pairs?? "
-                        + a.getValues().size() + "!="
-                        + annAfter.getValues().size());
-            }
-            for (int i = 0; i < a.getValues().size(); i++)
-            {
+            assertEquals(beforeName, afterName, "Deserialization failed");
+            assertEquals(a.getValues().size(), annAfter.getValues().size(),
+                    "Different numbers of element name value pairs??");
+            for (int i = 0; i < a.getValues().size(); i++) {
                 final ElementValuePairGen beforeElement = a.getValues().get(i);
                 final ElementValuePairGen afterElement = annAfter.getValues().get(i);
-                if (!beforeElement.getNameString().equals(
-                        afterElement.getNameString()))
-                {
-                    fail("Different names?? " + beforeElement.getNameString()
-                            + "!=" + afterElement.getNameString());
-                }
+                assertEquals(beforeElement.getNameString(), afterElement.getNameString(), "Different names??");
             }
         }
         catch (final IOException ioe)

--- a/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/AnnotationGenTestCase.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class AnnotationGenTestCase extends AbstractTestCase
 {
@@ -50,7 +49,7 @@ public class AnnotationGenTestCase extends AbstractTestCase
      * Programmatically construct an mutable annotation (AnnotationGen) object.
      */
     @Test
-    public void testConstructMutableAnnotation()
+    public void testConstructMutableAnnotation() throws IOException
     {
         // Create the containing class
         final ClassGen cg = createClassGen("HelloWorld");
@@ -124,35 +123,28 @@ public class AnnotationGenTestCase extends AbstractTestCase
         assertTrue(foundRIV, "Should have seen a RuntimeInvisibleAnnotation");
     }
 
-    private void checkSerialize(final AnnotationEntryGen a, final ConstantPoolGen cpg)
+    private void checkSerialize(final AnnotationEntryGen a, final ConstantPoolGen cpg) throws IOException
     {
-        try
-        {
-            final String beforeName = a.getTypeName();
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try (DataOutputStream dos = new DataOutputStream(baos)) {
-                a.dump(dos);
-                dos.flush();
-            }
-            final byte[] bs = baos.toByteArray();
-            final ByteArrayInputStream bais = new ByteArrayInputStream(bs);
-            AnnotationEntryGen annAfter;
-            try (DataInputStream dis = new DataInputStream(bais)) {
-                annAfter = AnnotationEntryGen.read(dis, cpg, a.isRuntimeVisible());
-            }
-            final String afterName = annAfter.getTypeName();
-            assertEquals(beforeName, afterName, "Deserialization failed");
-            assertEquals(a.getValues().size(), annAfter.getValues().size(),
-                    "Different numbers of element name value pairs??");
-            for (int i = 0; i < a.getValues().size(); i++) {
-                final ElementValuePairGen beforeElement = a.getValues().get(i);
-                final ElementValuePairGen afterElement = annAfter.getValues().get(i);
-                assertEquals(beforeElement.getNameString(), afterElement.getNameString(), "Different names??");
-            }
+        final String beforeName = a.getTypeName();
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(baos)) {
+            a.dump(dos);
+            dos.flush();
         }
-        catch (final IOException ioe)
-        {
-            fail("Unexpected exception whilst checking serialization: " + ioe);
+        final byte[] bs = baos.toByteArray();
+        final ByteArrayInputStream bais = new ByteArrayInputStream(bs);
+        AnnotationEntryGen annAfter;
+        try (DataInputStream dis = new DataInputStream(bais)) {
+            annAfter = AnnotationEntryGen.read(dis, cpg, a.isRuntimeVisible());
+        }
+        final String afterName = annAfter.getTypeName();
+        assertEquals(beforeName, afterName, "Deserialization failed");
+        assertEquals(a.getValues().size(), annAfter.getValues().size(),
+                "Different numbers of element name value pairs??");
+        for (int i = 0; i < a.getValues().size(); i++) {
+            final ElementValuePairGen beforeElement = a.getValues().get(i);
+            final ElementValuePairGen afterElement = annAfter.getValues().get(i);
+            assertEquals(beforeElement.getNameString(), afterElement.getNameString(), "Different names??");
         }
     }
 }

--- a/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
@@ -171,6 +171,6 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
                 return;
             }
         }
-        fail("Didnt find named element " + name);
+        fail("Didn't find named element " + name);
     }
 }

--- a/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
@@ -30,7 +30,6 @@ import org.apache.bcel.util.SyntheticRepository;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class FieldAnnotationsTestCase extends AbstractTestCase
 {
@@ -152,25 +151,5 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
         assertTrue(elementvalue.equals(envp.getValue().stringifyValue()),
                 "Expected element value " + elementvalue + " but was "
                         + envp.getValue().stringifyValue());
-    }
-
-    // helper methods
-    public void checkValue(final AnnotationEntry a, final String name, final String tostring)
-    {
-        for (int i = 0; i < a.getElementValuePairs().length; i++)
-        {
-            final ElementValuePair element = a.getElementValuePairs()[i];
-            if (element.getNameString().equals(name))
-            {
-                if (!element.getValue().stringifyValue().equals(tostring))
-                {
-                    fail("Expected element " + name + " to have value "
-                            + tostring + " but it had value "
-                            + element.getValue().stringifyValue());
-                }
-                return;
-            }
-        }
-        fail("Didn't find named element " + name);
     }
 }

--- a/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
@@ -29,6 +29,7 @@ import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FieldAnnotationsTestCase extends AbstractTestCase
@@ -114,9 +115,7 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
             System.err.println("With AnnotationEntrys: "
                     + dumpAnnotationEntries(f.getAnnotationEntries()));
         }
-        assertTrue(f.getAnnotationEntries().length == 2,
-                "Should be 2 AnnotationEntrys on this field, but there are "
-                        + f.getAnnotationEntries().length);
+        assertEquals(2, f.getAnnotationEntries().length, "Wrong number of AnnotationEntries");
     }
 
     // helper methods
@@ -138,18 +137,10 @@ public class FieldAnnotationsTestCase extends AbstractTestCase
     private void checkAnnotationEntry(final AnnotationEntry a, final String name, final String elementname,
             final String elementvalue)
     {
-        assertTrue(a.getAnnotationType().equals(name),
-                "Expected AnnotationEntry to have name " + name
-                        + " but it had name " + a.getAnnotationType());
-        assertTrue(a.getElementValuePairs().length == 1,
-                "Expected AnnotationEntry to have one element but it had "
-                        + a.getElementValuePairs().length);
+        assertEquals(name, a.getAnnotationType(), "Wrong AnnotationEntry name");
+        assertEquals(1, a.getElementValuePairs().length, "Wrong number of AnnotationEntry elements");
         final ElementValuePair envp = a.getElementValuePairs()[0];
-        assertTrue(elementname.equals(envp.getNameString()),
-                "Expected element name " + elementname + " but was "
-                        + envp.getNameString());
-        assertTrue(elementvalue.equals(envp.getValue().stringifyValue()),
-                "Expected element value " + elementvalue + " but was "
-                        + envp.getValue().stringifyValue());
+        assertEquals(envp.getNameString(), elementname, "Wrong element name");
+        assertEquals(envp.getValue().stringifyValue(), elementvalue, "Wrong element value");
     }
 }

--- a/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
@@ -360,8 +360,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
             final ElementValuePairGen element = (ElementValuePairGen) name;
             if (element.getNameString().equals("dval"))
             {
-                if (((SimpleElementValueGen) element.getValue())
-                        .stringifyValue().equals("33.4")) {
+                if (element.getValue().stringifyValue().equals("33.4")) {
                     found = true;
                 }
             }

--- a/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
@@ -91,24 +91,16 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         dumpClass(cg, "HelloWorld.class");
         final JavaClass jc = getClassFrom(".", "HelloWorld");
         final AnnotationEntry[] as = jc.getAnnotationEntries();
-        assertTrue(as.length == 2,
-                "Should be two AnnotationEntries but found " + as.length);
+        assertEquals(2, as.length, "Wrong number of AnnotationEntries");
         // TODO L??;
-        assertTrue(as[0].getAnnotationType().equals("LSimpleAnnotation;"),
-                "Name of annotation 1 should be LSimpleAnnotation; but it is "
-                                + as[0].getAnnotationType());
-        assertTrue(as[1].getAnnotationType().equals("LSimpleAnnotation;"),
-                "Name of annotation 2 should be LSimpleAnnotation; but it is "
-                                + as[1].getAnnotationType());
+        assertEquals("LSimpleAnnotation;", as[0].getAnnotationType(), "Wrong name of annotation 1");
+        assertEquals("LSimpleAnnotation;", as[1].getAnnotationType(), "Wrong name of annotation 2");
         final ElementValuePair[] vals = as[0].getElementValuePairs();
         final ElementValuePair nvp = vals[0];
-        assertTrue(nvp.getNameString().equals("id"),
-                "Name of element in SimpleAnnotation should be 'id' but it is " + nvp.getNameString());
+        assertEquals("id", nvp.getNameString(), "Wrong name of element in SimpleAnnotation");
         final ElementValue ev = nvp.getValue();
-        assertTrue(ev.getElementValueType() == ElementValue.PRIMITIVE_INT,
-                "Type of element value should be int but it is " + ev.getElementValueType());
-        assertTrue(ev.stringifyValue().equals("4"),
-                "Value of element should be 4 but it is " + ev.stringifyValue());
+        assertEquals(ElementValue.PRIMITIVE_INT, ev.getElementValueType(), "Wrong type of element value");
+        assertEquals("4", ev.stringifyValue(), "Wrong value of element");
         assertTrue(createTestdataFile("HelloWorld.class").delete());
     }
 
@@ -127,26 +119,22 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         buildClassContentsWithAnnotatedMethods(cg, cp, il);
         // Check annotation is OK
         int i = cg.getMethods()[0].getAnnotationEntries().length;
-        assertTrue(i == 1,
-                "Prior to dumping, main method should have 1 annotation but has " + i);
+        assertEquals(1, i, "Wrong number of annotations of main method prior to dumping");
         dumpClass(cg, "temp1" + File.separator + "HelloWorld.class");
         final JavaClass jc2 = getClassFrom("temp1", "HelloWorld");
         // Check annotation is OK
         i = jc2.getMethods()[0].getAnnotationEntries().length;
-        assertTrue(i == 1,
-                "JavaClass should say 1 annotation on main method but says " + i);
+        assertEquals(1, i, "Wrong number of annotation on JavaClass");
         final ClassGen cg2 = new ClassGen(jc2);
         // Check it now it is a ClassGen
         final Method[] m = cg2.getMethods();
         i = m[0].getAnnotationEntries().length;
-        assertTrue(i == 1,
-                "The main 'Method' should have one annotation but has " + i);
+        assertEquals(1, i, "Wrong number of annotations on the main 'Method'");
         final MethodGen mg = new MethodGen(m[0], cg2.getClassName(), cg2
                 .getConstantPool());
         // Check it finally when the Method is changed to a MethodGen
         i = mg.getAnnotationEntries().length;
-        assertTrue(i == 1,
-                "The main 'MethodGen' should have one annotation but has " + i);
+        assertEquals(1, i, "Wrong number of annotations on the main 'MethodGen'");
 
         assertTrue(wipe("temp1", "HelloWorld.class"));
     }
@@ -171,14 +159,10 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cg2 = new ClassGen(jc2);
         // Main method after reading the class back in
         final Method mainMethod1 = jc2.getMethods()[0];
-        assertTrue(mainMethod1.getAnnotationEntries().length == 1,
-                "The 'Method' should have one annotations but has "
-                        + mainMethod1.getAnnotationEntries().length);
+        assertEquals(1, mainMethod1.getAnnotationEntries().length, "Wrong number of annotations of the 'Method'");
         final MethodGen mainMethod2 = new MethodGen(mainMethod1, cg2.getClassName(),
                 cg2.getConstantPool());
-        assertTrue(mainMethod2.getAnnotationEntries().length == 1,
-                "The 'MethodGen' should have one annotation but has "
-                        + mainMethod2.getAnnotationEntries().length);
+        assertEquals(1, mainMethod2.getAnnotationEntries().length, "Wrong number of annotations of the 'MethodGen'");
         AnnotationEntryGen fruit = createFruitAnnotation(cg2.getConstantPool(), "Pear");
         mainMethod2.addAnnotationEntry(fruit);
         cg2.removeMethod(mainMethod1);
@@ -188,16 +172,12 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cg3 = new ClassGen(jc3);
         final Method mainMethod3 = cg3.getMethods()[1];
         final int i = mainMethod3.getAnnotationEntries().length;
-        assertTrue(i == 2,
-                "The 'Method' should now have two annotations but has " + i);
+        assertEquals(2, i, "Wrong number of annotations on the 'Method'");
         mainMethod2.removeAnnotationEntry(fruit);
-        assertTrue(mainMethod2.getAnnotationEntries().length == 1,
-                "The 'MethodGen' should have one annotation but has "
-                        + mainMethod2.getAnnotationEntries().length);
+        assertEquals(1, mainMethod2.getAnnotationEntries().length, "Wrong number of annotations on the 'MethodGen'");
         mainMethod2.removeAnnotationEntries();
-        assertTrue(mainMethod2.getAnnotationEntries().length == 0,
-                "The 'MethodGen' should have no annotations but has "
-                        + mainMethod2.getAnnotationEntries().length);
+        assertEquals(0, mainMethod2.getAnnotationEntries().length, 0,
+                "Wrong number of annotations on the 'MethodGen'");
         assertTrue(wipe("temp2", "HelloWorld.class"));
         assertTrue(wipe("temp3", "HelloWorld.class"));
     }
@@ -214,8 +194,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue(annotations.length == 1,
-                "Expected one annotation but found " + annotations.length);
+        assertEquals(1, annotations.length, "Wrong number of annotations");
     }
 
     /**
@@ -230,8 +209,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue(annotations.length == 1,
-                "Expected one annotation but found " + annotations.length);
+        assertEquals(1, annotations.length, "Wrong number of annotations");
     }
 
     /**
@@ -246,27 +224,23 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue(annotations.length == 1,
-                "Expected one annotation but found " + annotations.length);
+        assertEquals(1, annotations.length, "Wrong number of annotations");
         final AnnotationEntryGen a = annotations[0];
-        assertTrue(a.getValues().size() == 1,
-                "That annotation should only have one value but has " + a.getValues().size());
+        assertEquals(1, a.getValues().size(), "Wrong number of values for the annotation");
         final ElementValuePairGen nvp = a.getValues().get(0);
         final ElementValueGen value = nvp.getValue();
         assertTrue(value instanceof ArrayElementValueGen,
                 "Value should be ArrayElementValueGen but is " + value);
         final ArrayElementValueGen arrayValue = (ArrayElementValueGen) value;
-        assertTrue(arrayValue.getElementValuesSize() == 1,
-                "Array value should be size one but is " + arrayValue.getElementValuesSize());
+        assertEquals(1, arrayValue.getElementValuesSize(), "Wrong size of the array");
         final ElementValueGen innerValue = arrayValue.getElementValues().get(0);
         assertTrue(
                 innerValue instanceof AnnotationElementValueGen,
                 "Value in the array should be AnnotationElementValueGen but is " + innerValue);
         final AnnotationElementValueGen innerAnnotationValue = (AnnotationElementValueGen) innerValue;
-        assertTrue(innerAnnotationValue.getAnnotation().getTypeSignature().equals(
-                                "L"+PACKAGE_BASE_SIG+"/data/SimpleAnnotation;"),
-                "Should be called L"+PACKAGE_BASE_SIG+"/data/SimpleAnnotation; but is called: "
-                        + innerAnnotationValue.getAnnotation().getTypeName());
+        assertEquals("L" + PACKAGE_BASE_SIG + "/data/SimpleAnnotation;",
+                innerAnnotationValue.getAnnotation().getTypeSignature(),
+                "Wrong type signature");
 
         // check the three methods
         final Method[] methods = cgen.getMethods();
@@ -352,8 +326,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         // Check annotations are correctly preserved
         final AnnotationEntryGen[] annotations = cgen.getAnnotationEntries();
-        assertTrue(annotations.length == 1,
-                "Expected one annotation but found " + annotations.length);
+        assertEquals(1, annotations.length, "Wrong number of annotations");
         final List<?> l = annotations[0].getValues();
         boolean found = false;
         for (final Object name : l) {
@@ -379,8 +352,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         final ConstantPoolGen cp = cgen.getConstantPool();
         cgen.addAnnotationEntry(createFruitAnnotation(cp, "Pineapple"));
-        assertTrue(cgen.getAnnotationEntries().length == 2,
-                "Should now have two annotations but has " + cgen.getAnnotationEntries().length);
+        assertEquals(2, cgen.getAnnotationEntries().length, "Wrong number of annotations");
         dumpClass(cgen, "SimpleAnnotatedClass.class");
         assertTrue(wipe("SimpleAnnotatedClass.class"));
     }
@@ -396,8 +368,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         final ClassGen cgen = new ClassGen(jc);
         final ConstantPoolGen cp = cgen.getConstantPool();
         cgen.addAnnotationEntry(createCombinedAnnotation(cp));
-        assertTrue(cgen.getAnnotationEntries().length == 2,
-                "Should now have two annotations but has " + cgen.getAnnotationEntries().length);
+        assertEquals(2, cgen.getAnnotationEntries().length, "Wrong number of annotations");
         dumpClass(cgen, "SimpleAnnotatedClass.class");
         final JavaClass jc2 = getClassFrom(".", "SimpleAnnotatedClass");
         jc2.getAnnotationEntries();

--- a/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
@@ -263,7 +263,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
             }
             else
             {
-                fail("unexpected method "+method.getName());
+                fail(() -> "unexpected method " + method.getName());
             }
         }
     }
@@ -272,7 +272,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
     {
         final String methodName= method.getName();
         final AnnotationEntry[] annos= method.getAnnotationEntries();
-        assertEquals(expectedNumberAnnotations, annos.length, "For " + methodName);
+        assertEquals(expectedNumberAnnotations, annos.length, () -> "For " + methodName);
         if(expectedNumberAnnotations!=0)
         {
             assertArrayElementValue(nExpectedArrayValues, annos[0]);
@@ -299,7 +299,8 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         {
             final AnnotationEntry[] annos= parameterAnnotation.getAnnotationEntries();
             final int expectedLength = expectedNumberOfParmeterAnnotations[i++];
-            assertEquals(expectedLength, annos.length, methodName + " parameter " + i);
+            int j = i;
+            assertEquals(expectedLength, annos.length, () -> methodName + " parameter " + j);
             if(expectedLength!=0)
             {
                 assertSimpleElementValue(annos[0]);

--- a/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.FileSystems;
@@ -212,12 +211,12 @@ public class JdkGenericDumpTestCase {
 
     private File[] listJdkJars(String javaHome) throws Exception {
         final File javaLib = new File(javaHome, "lib");
-        return javaLib.listFiles((FileFilter) file -> file.getName().endsWith(".jar"));
+        return javaLib.listFiles(file -> file.getName().endsWith(".jar"));
     }
 
     private File[] listJdkModules(String javaHome) throws Exception {
         final File javaLib = new File(javaHome, "jmods");
-        return javaLib.listFiles((FileFilter) file -> file.getName().endsWith(".jmod"));
+        return javaLib.listFiles(file -> file.getName().endsWith(".jmod"));
     }
 
     private void testJar(final File file) throws Exception {

--- a/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/JdkGenericDumpTestCase.java
@@ -197,7 +197,7 @@ public class JdkGenericDumpTestCase {
         final InstructionList instructionList = new InstructionList(src);
         final byte[] out = instructionList.getByteCode();
         if (src.length == out.length) {
-            assertArrayEquals(src, out, name + ": " + method.toString());
+            assertArrayEquals(src, out, () -> name + ": " + method.toString());
         } else {
             System.out.println(name + ": " + method.toString() + " " + src.length + " " + out.length);
             System.out.println(bytesToHex(src));

--- a/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/MethodGenTestCase.java
@@ -68,7 +68,7 @@ public class MethodGenTestCase {
             }
         }
 
-        fail("Method " + name + " not found in class " + cls);
+        fail(() -> "Method " + name + " not found in class " + cls);
         return null;
     }
 

--- a/src/test/java/org/apache/bcel/verifier/AbstractVerifierTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/AbstractVerifierTestCase.java
@@ -23,7 +23,6 @@ import org.apache.bcel.classfile.JavaClass;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class AbstractVerifierTestCase {
 
@@ -35,7 +34,7 @@ public abstract class AbstractVerifierTestCase {
      * @param classname simple classname of the class to verify
      * @param message   message displayed if assertion fails
      */
-    public void assertVerifyOK(final String classname, final String message) {
+    public void assertVerifyOK(final String classname, final String message) throws ClassNotFoundException {
         final String testClassname = TEST_PACKAGE + classname;
         assertTrue(doAllPasses(testClassname), message);
     }
@@ -47,7 +46,7 @@ public abstract class AbstractVerifierTestCase {
      * @param classname simple classname of the class to verify
      * @param message   message displayed if assertion fails
      */
-    public void assertVerifyRejected(final String classname, final String message) {
+    public void assertVerifyRejected(final String classname, final String message) throws ClassNotFoundException {
         final String testClassname = TEST_PACKAGE + classname;
         assertFalse(doAllPasses(testClassname), message);
     }
@@ -58,16 +57,9 @@ public abstract class AbstractVerifierTestCase {
      * @param classname name of the class to verify
      * @return false if the verification fails, true otherwise
      */
-    public boolean doAllPasses(final String classname) {
-        int nbMethods = 0;
-
-        try {
-            final JavaClass jc = Repository.lookupClass(classname);
-            nbMethods = jc.getMethods().length;
-        } catch (final ClassNotFoundException e) {
-            fail(e.getMessage());
-            return false;
-        }
+    public boolean doAllPasses(final String classname) throws ClassNotFoundException {
+        final JavaClass jc = Repository.lookupClass(classname);
+        int nbMethods = jc.getMethods().length;
 
         final Verifier verifier = VerifierFactory.getVerifier(classname);
         VerificationResult result = verifier.doPass1();

--- a/src/test/java/org/apache/bcel/verifier/VerifierArrayAccessTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierArrayAccessTestCase.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class VerifierArrayAccessTestCase extends AbstractVerifierTestCase {
 
     @Test
-    public void testInvalidArrayAccess() throws IOException {
+    public void testInvalidArrayAccess() throws IOException, ClassNotFoundException {
         new TestArrayAccess03Creator().create();
         assertVerifyRejected("TestArrayAccess03", "Verification of an arraystore instruction on an object must fail.");
         new TestArrayAccess04Creator().create();
@@ -37,7 +37,7 @@ public class VerifierArrayAccessTestCase extends AbstractVerifierTestCase {
     }
 
     @Test
-    public void testValidArrayAccess() throws IOException {
+    public void testValidArrayAccess() throws IOException, ClassNotFoundException {
         assertVerifyOK("TestArrayAccess01",
                 "Verification of an arraystore instruction on an array that is not compatible with the stored element must pass.");
         new TestArrayAccess02Creator().create();

--- a/src/test/java/org/apache/bcel/verifier/VerifierInvokeTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierInvokeTestCase.java
@@ -23,23 +23,23 @@ import org.junit.jupiter.api.Test;
 public class VerifierInvokeTestCase extends AbstractVerifierTestCase {
 
     @Test
-    public void testLegalInvokeVirtual() {
+    public void testLegalInvokeVirtual() throws ClassNotFoundException {
         assertVerifyOK("TestLegalInvokeVirtual01", "Verification of invokevirtual on method defined in superclass must pass.");
         assertVerifyOK("TestLegalInvokeVirtual02", "Verification of invokevirtual on method defined in superinterface must pass.");
     }
 
     @Test
-    public void testLegalInvokeStatic() {
+    public void testLegalInvokeStatic() throws ClassNotFoundException {
         assertVerifyOK("TestLegalInvokeStatic01", "Verification of invokestatic on method defined in superclass must pass.");
     }
 
     @Test
-    public void testLegalInvokeInterface() {
+    public void testLegalInvokeInterface() throws ClassNotFoundException {
         assertVerifyOK("TestLegalInvokeInterface01", "Verification of invokeinterface on method defined in superinterface must pass.");
     }
 
     @Test
-    public void testLegalInvokeSpecial() {
+    public void testLegalInvokeSpecial() throws ClassNotFoundException {
         assertVerifyOK("TestLegalInvokeSpecial01", "Verification of invokespecial on method defined in superclass must pass.");
         assertVerifyOK("TestLegalInvokeSpecial02", "Verification of invokespecial on method defined in superclass must pass.");
     }

--- a/src/test/java/org/apache/bcel/verifier/VerifierReturnTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifierReturnTestCase.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 public class VerifierReturnTestCase extends AbstractVerifierTestCase {
 
     @Test
-    public void testInvalidReturn() throws IOException {
+    public void testInvalidReturn() throws IOException, ClassNotFoundException {
         new TestReturn01Creator().create();
         assertVerifyRejected("TestReturn01", "Verification of a void method that returns an object must fail.");
         new TestReturn03Creator().create();
@@ -34,7 +34,7 @@ public class VerifierReturnTestCase extends AbstractVerifierTestCase {
     }
 
     @Test
-    public void testValidReturn() {
+    public void testValidReturn() throws ClassNotFoundException {
         assertVerifyOK("TestReturn02", "Verification of a method that returns a newly created object must pass.");
         assertVerifyOK("TestArray01", "Verification of a method that returns an array must pass.");
     }


### PR DESCRIPTION
As a followup to #68 (BCEL-342), now that the tests are migrated to JUnit Jupiter, it's a good opportunity to go over the assertions and clean them up.
The main gain from this PR is improving the readability and maintainability of the tests. There is a theoretical performance improvement here too, but my benchmarking it on my limited resources, I could not observe a meaningful difference.

This PR offers the following improvements:

1. Remvoes unused methods from test classes
1. Removes unnescesary casts from test classes
1. Simplifies the idiom of `assertTrue(!condition, message)` to `assertTrue(condtion, message)` in order to make the tests easier to understand
1. Simplifies the idiom of `assertTrue(x.equals(y), message)` to `assertEquals(x, y, message)` in order to make the tests easier to understand. As a side bonus, most of these messages were constructed dynamically with the values of `x` and `y`, and using `assertEquals` allowed relying on JUnit's existing functionality to display them in case of failure instead of reinventing the wheel. This not only shortens the code by removing boilerplate logical, but also theoritically improves performance as this string needs to be constructed only in case of a test failure.
1. Simplifies the idiom of `assertTrue(primitiveX == primitiveY, message)` to `assertEquals(x, y, message)`, for similar benefits as the previous point.
1. Simplifies the idiom of `if(!x.equals(y)) fail(message)` to `assertEquals(x, y, message)`, for similar benefits as the previous point.
1. Simplifies the idiom of catching an exception and explicitly failing to allowing the test methods to throw those exceptions and have the test runner handle it.
1. In the remaining cases where an assertion had a non-constant string message it was replaced with a `Supplier<String>` that supplies the same message so that it's only evaluated in case of an assertion failure.
1. Some minor typos in assertion messages were fixed where noticed.