### PR TITLE
Force unsigned short for LineNumber.toString()

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/LineNumber.java
+++ b/src/main/java/org/apache/bcel/classfile/LineNumber.java
@@ -96,7 +96,7 @@ public final class LineNumber implements Cloneable, Node {
      * @return Corresponding source line
      */
     public int getLineNumber() {
-        return 0xffff & lineNumber;
+        return lineNumber & 0xffff;
     }
 
 
@@ -104,7 +104,7 @@ public final class LineNumber implements Cloneable, Node {
      * @return PC in code
      */
     public int getStartPC() {
-        return  0xffff & startPc;
+        return startPc & 0xffff;
     }
 
 
@@ -129,7 +129,7 @@ public final class LineNumber implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "LineNumber(" + startPc + ", " + lineNumber + ")";
+        return "LineNumber(" + (((int) startPc) & 0xffff) + ", " + (((int) lineNumber) & 0xffff) + ")";
     }
 
 

--- a/src/main/java/org/apache/bcel/classfile/LineNumber.java
+++ b/src/main/java/org/apache/bcel/classfile/LineNumber.java
@@ -129,7 +129,7 @@ public final class LineNumber implements Cloneable, Node {
      */
     @Override
     public String toString() {
-        return "LineNumber(" + (((int) startPc) & 0xffff) + ", " + (((int) lineNumber) & 0xffff) + ")";
+        return "LineNumber(" + getStartPC() + ", " + getLineNumber() + ")";
     }
 
 

--- a/src/test/java/org/apache/bcel/PLSETestCase.java
+++ b/src/test/java/org/apache/bcel/PLSETestCase.java
@@ -20,6 +20,8 @@ package org.apache.bcel;
 
 import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.LineNumber;
+import org.apache.bcel.classfile.LineNumberTable;
 import org.apache.bcel.classfile.LocalVariable;
 import org.apache.bcel.classfile.LocalVariableTable;
 import org.apache.bcel.classfile.Method;
@@ -34,6 +36,7 @@ import org.apache.bcel.generic.Type;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class PLSETestCase extends AbstractTestCase
 {
@@ -114,6 +117,25 @@ public class PLSETestCase extends AbstractTestCase
         final LocalVariable new_lv = new_lvt.getLocalVariable(2, 4);  // 'i'
         //System.out.println(new_lv);
         assertEquals(lv.getLength(), new_lv.getLength(), "live range length");
+    }
+
+    /**
+     * BCEL-361: LineNumber.toString() treats code offset as signed
+     */
+    @Test
+    public void testB361() throws Exception
+    {
+        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.LargeMethod");
+        final Method[] methods = clazz.getMethods();
+        final Method m = methods[0];
+        //System.out.println(m.getName());
+        final Code code = m.getCode();
+        final LineNumberTable lnt = code.getLineNumberTable();
+        final LineNumber[] lineNumbers = lnt.getLineNumberTable();
+        final String data = lineNumbers[lineNumbers.length - 1].toString();
+        //System.out.println(data);
+        //System.out.println(data.contains("-"));
+        assertFalse(data.contains("-"), "code offsets must be positive");
     }
 
     /**

--- a/src/test/java/org/apache/bcel/PLSETestCase.java
+++ b/src/test/java/org/apache/bcel/PLSETestCase.java
@@ -47,7 +47,7 @@ public class PLSETestCase extends AbstractTestCase
     @Test
     public void testB208() throws ClassNotFoundException
     {
-        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestClass");
+        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME + ".data.PLSETestClass");
         final ClassGen gen = new ClassGen(clazz);
         final ConstantPoolGen pool = gen.getConstantPool();
         final Method m = gen.getMethodAt(1);
@@ -64,7 +64,7 @@ public class PLSETestCase extends AbstractTestCase
     @Test
     public void testB79() throws ClassNotFoundException
     {
-        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestClass");
+        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME + ".data.PLSETestClass");
         final ClassGen gen = new ClassGen(clazz);
         final ConstantPoolGen pool = gen.getConstantPool();
         final Method m = gen.getMethodAt(2);
@@ -83,7 +83,7 @@ public class PLSETestCase extends AbstractTestCase
     @Test
     public void testB262() throws ClassNotFoundException
     {
-        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestEnum");
+        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME + ".data.PLSETestEnum");
         final ClassGen gen = new ClassGen(clazz);
         final ConstantPoolGen pool = gen.getConstantPool();
         // get the values() method
@@ -105,7 +105,7 @@ public class PLSETestCase extends AbstractTestCase
     @Test
     public void testB295() throws Exception
     {
-        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.PLSETestClass2");
+        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME + ".data.PLSETestClass2");
         final ClassGen cg = new ClassGen(clazz);
         final ConstantPoolGen pool = cg.getConstantPool();
         final Method m = cg.getMethodAt(1);  // 'main'
@@ -125,7 +125,7 @@ public class PLSETestCase extends AbstractTestCase
     @Test
     public void testB361() throws Exception
     {
-        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.LargeMethod");
+        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME + ".data.LargeMethod");
         final Method[] methods = clazz.getMethods();
         final Method m = methods[0];
         //System.out.println(m.getName());
@@ -145,7 +145,7 @@ public class PLSETestCase extends AbstractTestCase
     public void testCoverage() throws ClassNotFoundException, java.io.IOException
     {
         // load a class with a wide variety of byte codes - including tableswitch and lookupswitch
-        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME+".data.ConstantPoolX");
+        final JavaClass clazz = getTestClass(PACKAGE_BASE_NAME + ".data.ConstantPoolX");
         for (final Method m: clazz.getMethods()) {
             final String signature = m.getSignature();
             Utility.methodTypeToSignature(Utility.methodSignatureReturnType(signature),

--- a/src/test/java/org/apache/bcel/data/LargeMethod.java
+++ b/src/test/java/org/apache/bcel/data/LargeMethod.java
@@ -18,8 +18,9 @@
 
 package org.apache.bcel.data;
 
-    // Due to the javac implemtation of try finally, this class
-    // generates a huge (>32767 code bytes) <init> method.
+    // Due to the way try finally is implemented in the standard java compiler
+    // from Oracle, this class generates a huge (>32767 code bytes) <init> method.
+    // Verified with javac versions 1.8.0_261, 11.0.10 and 17.0.1.
     class LargeMethod {{
       int a;
       try {a=0;} finally {

--- a/src/test/java/org/apache/bcel/data/LargeMethod.java
+++ b/src/test/java/org/apache/bcel/data/LargeMethod.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.bcel.data;
+
+    // Due to the javac implemtation of try finally, this class
+    // generates a huge (>32767 code bytes) <init> method.
+    class LargeMethod {{
+      int a;
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      try {a=0;} finally {
+      a=0;
+      }}}}}}}}}}}}
+    }}


### PR DESCRIPTION
Ensure startPc and lineNumber are treated as unsigned short in LineNumber.toString()