### PR TITLE
Close resources

### DIFF
--- a/src/examples/Package.java
+++ b/src/examples/Package.java
@@ -160,14 +160,13 @@ public class Package {
 
         System.out.println("Creating jar file: " + defaultJar);
 
-        // starting processing: Grab from the dependents list an add back to it
+        // starting processing: Grab from the dependents list and add back to it
         // and the allClasses list. see addDependents
         while (!dependents.isEmpty()) {
             final String name = dependents.firstKey();
             final String from = dependents.remove(name);
             if (allClasses.get(name) == null) {
-                try {
-                    final InputStream is = classPath.getInputStream(name);
+                try (final InputStream is = classPath.getInputStream(name)) {
                     clazz = new ClassParser(is, name).parse();
                     addDependents(clazz);
                 } catch (final IOException e) {

--- a/src/main/java/org/apache/bcel/Repository.java
+++ b/src/main/java/org/apache/bcel/Repository.java
@@ -229,8 +229,7 @@ public abstract class Repository {
      *  found
      */
     public static ClassPath.ClassFile lookupClassFile( final String class_name ) {
-        try {
-            final ClassPath path = repository.getClassPath();
+        try (final ClassPath path = repository.getClassPath()) {
             if (path == null) {
                 return null;
             }

--- a/src/main/java/org/apache/bcel/util/AttributeHTML.java
+++ b/src/main/java/org/apache/bcel/util/AttributeHTML.java
@@ -17,6 +17,7 @@
  */
 package org.apache.bcel.util;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
@@ -41,7 +42,7 @@ import org.apache.bcel.classfile.Utility;
 /**
  * Convert found attributes into HTML file.
  */
-final class AttributeHTML {
+final class AttributeHTML implements Closeable {
 
     private final String className; // name of current class
     private final PrintWriter printWriter; // file to write to
@@ -63,7 +64,8 @@ final class AttributeHTML {
     }
 
 
-    void close() {
+    @Override
+    public void close() {
         printWriter.println("</TABLE></BODY></HTML>");
         printWriter.close();
     }

--- a/src/main/java/org/apache/bcel/util/Class2HTML.java
+++ b/src/main/java/org/apache/bcel/util/Class2HTML.java
@@ -207,12 +207,12 @@ public class Class2HTML implements Constants {
         /*
          * Attributes can't be written in one step, so we just open a file which will be written consequently.
          */
-        final AttributeHTML attributeHtml = new AttributeHTML(dir, className, constantPool, constantHtml, charset);
-        new MethodHTML(dir, className, methods, javaClass.getFields(), constantHtml, attributeHtml, charset);
-        // Write main file (with frames, yuk)
-        writeMainHTML(attributeHtml, charset);
-        new CodeHTML(dir, className, methods, constantPool, constantHtml, charset);
-        attributeHtml.close();
+        try (final AttributeHTML attributeHtml = new AttributeHTML(dir, className, constantPool, constantHtml, charset)) {
+            new MethodHTML(dir, className, methods, javaClass.getFields(), constantHtml, attributeHtml, charset);
+            // Write main file (with frames, yuk)
+            writeMainHTML(attributeHtml, charset);
+            new CodeHTML(dir, className, methods, constantPool, constantHtml, charset);
+        }
     }
 
 

--- a/src/main/java/org/apache/bcel/util/CodeHTML.java
+++ b/src/main/java/org/apache/bcel/util/CodeHTML.java
@@ -57,16 +57,17 @@ private final String className; // name of current class
 //        this.methods = methods;
         this.constantPool = constant_pool;
         this.constantHtml = constant_html;
-        printWriter = new PrintWriter(dir + class_name + "_code.html", charset.name());
-        printWriter.print("<HTML><head><meta charset=\"");
-        printWriter.print(charset.name());
-        printWriter.println("\"></head>");
-        printWriter.println("<BODY BGCOLOR=\"#C0C0C0\">");
-        for (int i = 0; i < methods.length; i++) {
-            writeMethod(methods[i], i);
+        try (PrintWriter newPrintWriter = new PrintWriter(dir + class_name + "_code.html", charset.name())) {
+            printWriter = newPrintWriter;
+            printWriter.print("<HTML><head><meta charset=\"");
+            printWriter.print(charset.name());
+            printWriter.println("\"></head>");
+            printWriter.println("<BODY BGCOLOR=\"#C0C0C0\">");
+            for (int i = 0; i < methods.length; i++) {
+                writeMethod(methods[i], i);
+            }
+            printWriter.println("</BODY></HTML>");
         }
-        printWriter.println("</BODY></HTML>");
-        printWriter.close();
     }
 
 

--- a/src/main/java/org/apache/bcel/util/ConstantHTML.java
+++ b/src/main/java/org/apache/bcel/util/ConstantHTML.java
@@ -54,27 +54,28 @@ final class ConstantHTML {
         this.constantPool = constant_pool;
         this.methods = methods;
         constants = constant_pool.getConstantPool();
-        printWriter = new PrintWriter(dir + class_name + "_cp.html", charset.name());
-        constantRef = new String[constants.length];
-        constantRef[0] = "&lt;unknown&gt;";
-        printWriter.print("<HTML><head><meta charset=\"");
-        printWriter.print(charset.name());
-        printWriter.println("\"></head>");
-        printWriter.println("<BODY BGCOLOR=\"#C0C0C0\"><TABLE BORDER=0>");
-        // Loop through constants, constants[0] is reserved
-        for (int i = 1; i < constants.length; i++) {
-            if (i % 2 == 0) {
-                printWriter.print("<TR BGCOLOR=\"#C0C0C0\"><TD>");
-            } else {
-                printWriter.print("<TR BGCOLOR=\"#A0A0A0\"><TD>");
+        try (PrintWriter newPrintWriter = new PrintWriter(dir + class_name + "_cp.html", charset.name())) {
+            printWriter = newPrintWriter;
+            constantRef = new String[constants.length];
+            constantRef[0] = "&lt;unknown&gt;";
+            printWriter.print("<HTML><head><meta charset=\"");
+            printWriter.print(charset.name());
+            printWriter.println("\"></head>");
+            printWriter.println("<BODY BGCOLOR=\"#C0C0C0\"><TABLE BORDER=0>");
+            // Loop through constants, constants[0] is reserved
+            for (int i = 1; i < constants.length; i++) {
+                if (i % 2 == 0) {
+                    printWriter.print("<TR BGCOLOR=\"#C0C0C0\"><TD>");
+                } else {
+                    printWriter.print("<TR BGCOLOR=\"#A0A0A0\"><TD>");
+                }
+                if (constants[i] != null) {
+                    writeConstant(i);
+                }
+                printWriter.print("</TD></TR>\n");
             }
-            if (constants[i] != null) {
-                writeConstant(i);
-            }
-            printWriter.print("</TD></TR>\n");
+            printWriter.println("</TABLE></BODY></HTML>");
         }
-        printWriter.println("</TABLE></BODY></HTML>");
-        printWriter.close();
     }
 
 

--- a/src/main/java/org/apache/bcel/util/MethodHTML.java
+++ b/src/main/java/org/apache/bcel/util/MethodHTML.java
@@ -45,25 +45,26 @@ final class MethodHTML {
         this.className = className;
         this.attributeHtml = attributeHtml;
         this.constantHtml = constantHtml;
-        printWriter = new PrintWriter(dir + className + "_methods.html", charset.name());
-        printWriter.print("<HTML><head><meta charset=\"");
-        printWriter.print(charset.name());
-        printWriter.println("\"></head>");
-        printWriter.println("<BODY BGCOLOR=\"#C0C0C0\"><TABLE BORDER=0>");
-        printWriter.println("<TR><TH ALIGN=LEFT>Access&nbsp;flags</TH><TH ALIGN=LEFT>Type</TH>"
-                + "<TH ALIGN=LEFT>Field&nbsp;name</TH></TR>");
-        for (final Field field : fields) {
-            writeField(field);
+        try (PrintWriter newPrintWriter = new PrintWriter(dir + className + "_methods.html", charset.name())) {
+            printWriter = newPrintWriter;
+            printWriter.print("<HTML><head><meta charset=\"");
+            printWriter.print(charset.name());
+            printWriter.println("\"></head>");
+            printWriter.println("<BODY BGCOLOR=\"#C0C0C0\"><TABLE BORDER=0>");
+            printWriter.println("<TR><TH ALIGN=LEFT>Access&nbsp;flags</TH><TH ALIGN=LEFT>Type</TH>"
+                    + "<TH ALIGN=LEFT>Field&nbsp;name</TH></TR>");
+            for (final Field field : fields) {
+                writeField(field);
+            }
+            printWriter.println("</TABLE>");
+            printWriter.println("<TABLE BORDER=0><TR><TH ALIGN=LEFT>Access&nbsp;flags</TH>"
+                    + "<TH ALIGN=LEFT>Return&nbsp;type</TH><TH ALIGN=LEFT>Method&nbsp;name</TH>"
+                    + "<TH ALIGN=LEFT>Arguments</TH></TR>");
+            for (int i = 0; i < methods.length; i++) {
+                writeMethod(methods[i], i);
+            }
+            printWriter.println("</TABLE></BODY></HTML>");
         }
-        printWriter.println("</TABLE>");
-        printWriter.println("<TABLE BORDER=0><TR><TH ALIGN=LEFT>Access&nbsp;flags</TH>"
-                + "<TH ALIGN=LEFT>Return&nbsp;type</TH><TH ALIGN=LEFT>Method&nbsp;name</TH>"
-                + "<TH ALIGN=LEFT>Arguments</TH></TR>");
-        for (int i = 0; i < methods.length; i++) {
-            writeMethod(methods[i], i);
-        }
-        printWriter.println("</TABLE></BODY></HTML>");
-        printWriter.close();
     }
 
 

--- a/src/test/java/org/apache/bcel/AbstractTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractTestCase.java
@@ -19,6 +19,7 @@
 package org.apache.bcel;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,9 +64,12 @@ public abstract class AbstractTestCase
 
     public SyntheticRepository createRepos(final String cpentry)
     {
-        final ClassPath cp = new ClassPath("target" + File.separator + "testdata"
-                + File.separator + cpentry + File.separator);
-        return SyntheticRepository.getInstance(cp);
+        try (ClassPath cp = new ClassPath("target" + File.separator + "testdata"
+                + File.separator + cpentry + File.separator)) {
+            return SyntheticRepository.getInstance(cp);
+        } catch (IOException e) {
+            throw new Error(e);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/bcel/AbstractTestCase.java
+++ b/src/test/java/org/apache/bcel/AbstractTestCase.java
@@ -20,6 +20,7 @@ package org.apache.bcel;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,7 +69,7 @@ public abstract class AbstractTestCase
                 + File.separator + cpentry + File.separator)) {
             return SyntheticRepository.getInstance(cp);
         } catch (IOException e) {
-            throw new Error(e);
+            throw new UncheckedIOException(e);
         }
     }
 


### PR DESCRIPTION
BCEL sometimes fails to close a resource.  This can lead to degraded performance, especially on long runs (eg, when being run by a server/daemon or when running on a large amount of code).

This pull request ensures that the resources are closed, even if an exception is thrown.

The diffs look large, but they are mostly indentation changes.