### PR TITLE
BCEL-363 Enforce MAX_CP_ENTRIES in ConstantPoolGen and ConstantPool.dump

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/ConstantPool.java
+++ b/src/main/java/org/apache/bcel/classfile/ConstantPool.java
@@ -230,8 +230,15 @@ public class ConstantPool implements Cloneable, Node {
      * @throws IOException if problem in writeShort or dump
      */
     public void dump(final DataOutputStream file) throws IOException {
-        file.writeShort(constantPool.length);
-        for (int i = 1; i < constantPool.length; i++) {
+        /*
+         * Constants over the size of the constant pool shall not be written out.
+         * This is a redundant measure as the ConstantPoolGen should have already
+         * reported an error back in the situation.
+        */
+        int size = Math.min(constantPool.length, Const.MAX_CP_ENTRIES);
+
+        file.writeShort(size);
+        for (int i = 1; i < size; i++) {
             if (constantPool[i] != null) {
                 constantPool[i].dump(file);
             }

--- a/src/main/java/org/apache/bcel/generic/ConstantPoolGen.java
+++ b/src/main/java/org/apache/bcel/generic/ConstantPoolGen.java
@@ -109,7 +109,7 @@ public class ConstantPoolGen {
     public ConstantPoolGen(final Constant[] cs) {
         final StringBuilder sb = new StringBuilder(DEFAULT_BUFFER_SIZE);
 
-        size = Math.max(DEFAULT_BUFFER_SIZE, cs.length + 64);
+        size = Math.min(Math.max(DEFAULT_BUFFER_SIZE, cs.length + 64), Const.MAX_CP_ENTRIES + 1);
         constants = new Constant[size];
 
         System.arraycopy(cs, 0, constants, 0, cs.length);
@@ -561,9 +561,18 @@ public class ConstantPoolGen {
      * Resize internal array of constants.
      */
     protected void adjustSize() {
+        // 3 extra spaces are needed as some entries may take 3 slots
+        if (index + 3 >= Const.MAX_CP_ENTRIES + 1) {
+            throw new RuntimeException("The number of constants " + (index + 3)
+                    + " is over the size of the constant pool: "
+                    + Const.MAX_CP_ENTRIES);
+        }
+
         if (index + 3 >= size) {
             final Constant[] cs = constants;
             size *= 2;
+            // the constant array shall not exceed the size of the constant pool
+            size = Math.min(size, Const.MAX_CP_ENTRIES + 1);
             constants = new Constant[size];
             System.arraycopy(cs, 0, constants, 0, index);
         }


### PR DESCRIPTION
Reapplies the fix in https://github.com/openjdk/jdk11u/commit/13bf52c8d876528a43be7cb77a1f452d29a21492 but using the Const constant for the constant pool size limit.