### PR TITLE
Keep ConstantPool.getConstant(int) backward compatible with v6.5.0

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/ConstantPool.java
+++ b/src/main/java/org/apache/bcel/classfile/ConstantPool.java
@@ -303,6 +303,18 @@ public class ConstantPool implements Cloneable, Node, Iterable<Constant> {
             throw new ClassFormatException("Invalid constant pool reference: " + index + ". Constant pool size is: " + constantPool.length);
         }
         final T c = castTo.cast(constantPool[index]);
+        if (c == null) {
+            if (index == 0) {
+                // the 0th element is always null
+            } else {
+                Constant prev = constantPool[index - 1];
+                if (prev != null && (prev.getTag() == Const.CONSTANT_Double || prev.getTag() == Const.CONSTANT_Long)) {
+                    // OpenJDK will skip index right after the double/long const value
+                } else {
+                    throw new ClassFormatException("Constant pool at index " + index + " is null.");
+                }
+            }
+        }
         return c;
     }
 

--- a/src/main/java/org/apache/bcel/classfile/ConstantPool.java
+++ b/src/main/java/org/apache/bcel/classfile/ConstantPool.java
@@ -303,9 +303,6 @@ public class ConstantPool implements Cloneable, Node, Iterable<Constant> {
             throw new ClassFormatException("Invalid constant pool reference: " + index + ". Constant pool size is: " + constantPool.length);
         }
         final T c = castTo.cast(constantPool[index]);
-        if (c == null) {
-            throw new ClassFormatException("Constant pool at index " + index + " is null.");
-        }
         return c;
     }
 

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -17,6 +17,9 @@
 
 package org.apache.bcel.classfile;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.bcel.AbstractTestCase;
 import org.apache.bcel.Const;
 import org.apache.bcel.generic.ConstantPoolGen;
@@ -26,8 +29,6 @@ import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.util.ClassPath;
 import org.apache.bcel.util.ClassPathRepository;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class ConstantPoolTestCase extends AbstractTestCase {
 

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -98,5 +98,5 @@ class ClassWithDoubleConstantPoolItem {
 }
 
 class ClassWithLongConstantPoolItem {
-    long d = 42; // here is the key; we need a double constant value
+    long l = 42; // here is the key; we need a double constant value
 }

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -17,16 +17,17 @@
 
 package org.apache.bcel.classfile;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.apache.bcel.AbstractTestCase;
 import org.apache.bcel.Const;
 import org.apache.bcel.generic.ConstantPoolGen;
 import org.apache.bcel.generic.InstructionHandle;
 import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.MethodGen;
+import org.apache.bcel.util.ClassPath;
+import org.apache.bcel.util.ClassPathRepository;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConstantPoolTestCase extends AbstractTestCase {
 
@@ -67,4 +68,19 @@ public class ConstantPoolTestCase extends AbstractTestCase {
         }
         assertThrows(IllegalStateException.class, () -> cp.addLong(0));
     }
+
+    @Test
+    public void constantPoolItemWontThrowClassFormatException() throws ClassNotFoundException {
+        ClassPath cp = new ClassPath("target/test-classes/org/apache/bcel/classfile");
+        JavaClass c = new ClassPathRepository(cp).loadClass("ClassWithNullConstantPoolItem");
+
+        ConstantPool pool = c.getConstantPool();
+        for (int i = 1; i < pool.getLength(); ++i) {
+            pool.getConstant(i);
+        }
+    }
+}
+
+class ClassWithNullConstantPoolItem {
+    double d = 42; // here is the key; we need a double constant value
 }

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolTestCase.java
@@ -71,9 +71,20 @@ public class ConstantPoolTestCase extends AbstractTestCase {
     }
 
     @Test
-    public void constantPoolItemWontThrowClassFormatException() throws ClassNotFoundException {
+    public void doubleConstantWontThrowClassFormatException() throws ClassNotFoundException {
         ClassPath cp = new ClassPath("target/test-classes/org/apache/bcel/classfile");
-        JavaClass c = new ClassPathRepository(cp).loadClass("ClassWithNullConstantPoolItem");
+        JavaClass c = new ClassPathRepository(cp).loadClass("ClassWithDoubleConstantPoolItem");
+
+        ConstantPool pool = c.getConstantPool();
+        for (int i = 1; i < pool.getLength(); ++i) {
+            pool.getConstant(i);
+        }
+    }
+
+    @Test
+    public void longConstantWontThrowClassFormatException() throws ClassNotFoundException {
+        ClassPath cp = new ClassPath("target/test-classes/org/apache/bcel/classfile");
+        JavaClass c = new ClassPathRepository(cp).loadClass("ClassWithLongConstantPoolItem");
 
         ConstantPool pool = c.getConstantPool();
         for (int i = 1; i < pool.getLength(); ++i) {
@@ -82,6 +93,10 @@ public class ConstantPoolTestCase extends AbstractTestCase {
     }
 }
 
-class ClassWithNullConstantPoolItem {
+class ClassWithDoubleConstantPoolItem {
     double d = 42; // here is the key; we need a double constant value
+}
+
+class ClassWithLongConstantPoolItem {
+    long d = 42; // here is the key; we need a double constant value
 }

--- a/src/test/java/org/apache/bcel/verifier/VerifyBadClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifyBadClassesTestCase.java
@@ -34,7 +34,6 @@ import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/java/org/apache/bcel/verifier/VerifyBadClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifyBadClassesTestCase.java
@@ -34,6 +34,7 @@ import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.ExecuteWatchdog;
 import org.apache.commons.exec.PumpStreamHandler;
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -122,6 +123,7 @@ public class VerifyBadClassesTestCase {
      * BCEL-308: NullPointerException in Verifier Pass 3A
      */
     @Test
+    @Disabled("ConstantPool item could be null even when class file is valid")
     public void testB308() {
         testVerify("issue308", "Hello");
     }

--- a/src/test/java/org/apache/bcel/verifier/VerifyBadClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/verifier/VerifyBadClassesTestCase.java
@@ -123,7 +123,6 @@ public class VerifyBadClassesTestCase {
      * BCEL-308: NullPointerException in Verifier Pass 3A
      */
     @Test
-    @Disabled("ConstantPool item could be null even when class file is valid")
     public void testB308() {
         testVerify("issue308", "Hello");
     }


### PR DESCRIPTION
Hello, thanks for keeping commons-bcel maintained! It surely helps the Java community a lot. 🙌 
I'm using commons-bcel to maintain bytecode analysis tool like SpotBugs.

Today I found that BCEL v6.6.0 makes test cases in SpotBugs failed: https://github.com/spotbugs/spotbugs/pull/2213

The reason is that, `ConstantPool#getConstant(int)` throws a `ClassFormatException` if `constantPool[index]` is `null`. But it is possible even when the class file is valid: you can verify it by making a simple class like below:

```java
class ClassWithNullConstantPoolItem {
  double d = 42; // here is the key; we need a double constant value
}
```

Then `javac ClassWithNullConstantPoolItem.java && javap -v ClassWithNullConstantPoolItem` will print a constant pool like below:

```
Constant pool:
   #1 = Methodref          #6.#15         // java/lang/Object."<init>":()V
   #2 = Double             42.0d
   #4 = Fieldref           #5.#16         // ClassWithNullConstantPoolItem.d:D
```

We can confirm that there is no `#3`, and in such case, `getConstant(3)` becomes null.  
In our repository, [Issue389.java](https://github.com/spotbugs/spotbugs/blob/51e586bed98393e53559a38c1f9bd15f54514efa/spotbugsTestCases/src/java/ghIssues/Issue389.java) is one of such cases.

So in my opinion, it is not so good to throw `ClassFormatException`. Here I suggest rollback this change made in v6.6.0. Thanks for checking my PR!