### PR TITLE
added accessors to model and unit tests, javadoc comments

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/Code.java
+++ b/src/main/java/org/apache/bcel/classfile/Code.java
@@ -236,7 +236,9 @@ public final class Code extends Attribute {
     }
     
     /**
-     * @return LocalVariableTypeTable of Code, if it has one
+     * Gets the local variable type table attribute {@link LocalVariableTypeTable}.
+     * @return LocalVariableTypeTable of Code, if it has one, null otherwise.
+     * @since 6.7.1
      */
     public LocalVariableTypeTable getLocalVariableTypeTable() {
         for (final Attribute attribute : attributes) {

--- a/src/main/java/org/apache/bcel/classfile/Code.java
+++ b/src/main/java/org/apache/bcel/classfile/Code.java
@@ -234,6 +234,18 @@ public final class Code extends Attribute {
         }
         return null;
     }
+    
+    /**
+     * @return LocalVariableTypeTable of Code, if it has one
+     */
+    public LocalVariableTypeTable getLocalVariableTypeTable() {
+        for (final Attribute attribute : attributes) {
+            if (attribute instanceof LocalVariableTypeTable) {
+                return (LocalVariableTypeTable) attribute;
+            }
+        }
+        return null;
+    }
 
     /**
      * @return Number of local variables.

--- a/src/main/java/org/apache/bcel/classfile/Code.java
+++ b/src/main/java/org/apache/bcel/classfile/Code.java
@@ -234,7 +234,7 @@ public final class Code extends Attribute {
         }
         return null;
     }
-    
+
     /**
      * Gets the local variable type table attribute {@link LocalVariableTypeTable}.
      * @return LocalVariableTypeTable of Code, if it has one, null otherwise.

--- a/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
+++ b/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
@@ -174,7 +174,7 @@ public abstract class FieldOrMethod extends AccessFlags implements Cloneable, No
     /**
      * Gets attribute for given tag.
      * @return Attribute for given tag, null if not found.
-     * @see {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
+     * Refer to {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
      * @since 6.7.1
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
+++ b/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
@@ -172,12 +172,14 @@ public abstract class FieldOrMethod extends AccessFlags implements Cloneable, No
     }
 
     /**
+     * Gets attribute for given tag.
      * @return Attribute for given tag, null if not found.
      * @see {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
+     * @since 6.7.1
      */
     @SuppressWarnings("unchecked")
-    public final <T extends Attribute> T getAttribute(byte tag) {
-        for (Attribute attribute : getAttributes()) {
+    public final <T extends Attribute> T getAttribute(final byte tag) {
+        for (final Attribute attribute : getAttributes()) {
             if (attribute.getTag() == tag) {
                 return (T) attribute;
             }

--- a/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
+++ b/src/main/java/org/apache/bcel/classfile/FieldOrMethod.java
@@ -172,6 +172,20 @@ public abstract class FieldOrMethod extends AccessFlags implements Cloneable, No
     }
 
     /**
+     * @return Attribute for given tag, null if not found.
+     * @see {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
+     */
+    @SuppressWarnings("unchecked")
+    public final <T extends Attribute> T getAttribute(byte tag) {
+        for (Attribute attribute : getAttributes()) {
+            if (attribute.getTag() == tag) {
+                return (T) attribute;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @return Constant pool used by this object.
      */
     public final ConstantPool getConstantPool() {

--- a/src/main/java/org/apache/bcel/classfile/JavaClass.java
+++ b/src/main/java/org/apache/bcel/classfile/JavaClass.java
@@ -430,12 +430,14 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     }
 
     /**
+     * Gets attribute for given tag.
      * @return Attribute for given tag, null if not found.
      * @see {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
+     * @since 6.7.1
      */
     @SuppressWarnings("unchecked")
-    public final <T extends Attribute> T getAttribute(byte tag) {
-        for (Attribute attribute : getAttributes()) {
+    public final <T extends Attribute> T getAttribute(final byte tag) {
+        for (final Attribute attribute : getAttributes()) {
             if (attribute.getTag() == tag) {
                 return (T) attribute;
             }

--- a/src/main/java/org/apache/bcel/classfile/JavaClass.java
+++ b/src/main/java/org/apache/bcel/classfile/JavaClass.java
@@ -430,6 +430,20 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     }
 
     /**
+     * @return Attribute for given tag, null if not found.
+     * @see {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
+     */
+    @SuppressWarnings("unchecked")
+    public final <T extends Attribute> T getAttribute(byte tag) {
+        for (Attribute attribute : getAttributes()) {
+            if (attribute.getTag() == tag) {
+                return (T) attribute;
+            }
+        }
+        return null;
+    }
+
+    /**
      * @return class in binary format
      */
     public byte[] getBytes() {

--- a/src/main/java/org/apache/bcel/classfile/JavaClass.java
+++ b/src/main/java/org/apache/bcel/classfile/JavaClass.java
@@ -432,7 +432,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     /**
      * Gets attribute for given tag.
      * @return Attribute for given tag, null if not found.
-     * @see {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
+     * Refer to {@link org.apache.bcel.Const#ATTR_UNKNOWN} constants named ATTR_* for possible values.
      * @since 6.7.1
      */
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/apache/bcel/classfile/Method.java
+++ b/src/main/java/org/apache/bcel/classfile/Method.java
@@ -183,7 +183,7 @@ public final class Method extends FieldOrMethod {
     }
 
     /**
-     * @return LocalVariableTable of code attribute if any, i.e. the call is forwarded to the Code atribute.
+     * @return LocalVariableTable of code attribute if any, i.e. the call is forwarded to the Code attribute.
      */
     public LocalVariableTable getLocalVariableTable() {
         final Code code = getCode();
@@ -194,7 +194,9 @@ public final class Method extends FieldOrMethod {
     }
 
     /**
-     * @return LocalVariableTypeTable of code attribute if any, i.e. the call is forwarded to the Code atribute.
+     * Gets the local variable type table attribute {@link LocalVariableTypeTable}.
+     * @return LocalVariableTypeTable of code attribute if any, i.e. the call is forwarded to the Code attribute.
+     * @since 6.7.1
      */
     public LocalVariableTypeTable getLocalVariableTypeTable() {
         final Code code = getCode();

--- a/src/main/java/org/apache/bcel/classfile/Method.java
+++ b/src/main/java/org/apache/bcel/classfile/Method.java
@@ -194,6 +194,17 @@ public final class Method extends FieldOrMethod {
     }
 
     /**
+     * @return LocalVariableTypeTable of code attribute if any, i.e. the call is forwarded to the Code atribute.
+     */
+    public LocalVariableTypeTable getLocalVariableTypeTable() {
+        final Code code = getCode();
+        if (code == null) {
+            return null;
+        }
+        return code.getLocalVariableTypeTable();
+    }
+    
+    /**
      * @return Annotations on the parameters of a method
      * @since 6.0
      */

--- a/src/main/java/org/apache/bcel/classfile/Method.java
+++ b/src/main/java/org/apache/bcel/classfile/Method.java
@@ -205,7 +205,7 @@ public final class Method extends FieldOrMethod {
         }
         return code.getLocalVariableTypeTable();
     }
-    
+
     /**
      * @return Annotations on the parameters of a method
      * @since 6.0

--- a/src/main/java/org/apache/bcel/classfile/Module.java
+++ b/src/main/java/org/apache/bcel/classfile/Module.java
@@ -103,67 +103,79 @@ public final class Module extends Attribute {
     }
 
     /**
-     * 
+     * Gets version for this module.
      * @param cp Array of constants
      * @return version from constant pool, "0" if version index is 0
+     * @since 6.7.1
      */
     public String getVersion(final ConstantPool cp) {
         return moduleVersionIndex == 0 ? "0" : cp.getConstantString(moduleVersionIndex, Const.CONSTANT_Utf8);
     }
 
     /**
-     * 
+     * Gets flags for this module.
      * @return module flags
+     * @since 6.7.1
      */
     public int getModuleFlags() {
         return moduleFlags;
     }
 
     /**
-     * 
+     * Gets module name.
      * @param cp Array of constants
      * @return module name
+     * @since 6.7.1
      */
     public String getModuleName(final ConstantPool cp) {
         return cp.getConstantString(moduleNameIndex, Const.CONSTANT_Module);
     }
 
     /**
+     * Gets module name index.
      * @return the moduleNameIndex
+     * @since 6.7.1
      */
     public int getModuleNameIndex() {
         return moduleNameIndex;
     }
 
     /**
+     * Gets module version index.
      * @return the moduleVersionIndex
+     * @since 6.7.1
      */
     public int getModuleVersionIndex() {
         return moduleVersionIndex;
     }
 
     /**
+     * Gets count of uses.
      * @return the usesCount
+     * @since 6.7.1
      */
     public int getUsesCount() {
         return usesCount;
     }
 
     /**
+     * Gets index of uses.
      * @return the usesIndex
+     * @since 6.7.1
      */
     public int[] getUsesIndex() {
         return usesIndex;
     }
 
     /**
-     * 
+     * Gets the array of class names for this module's uses.
      * @param constantPool Array of constants usually obtained from the ClassFile object
      * @param compactClassName false for original constant pool value, true to replace '/' with '.'
      * @return array of used class names
+     * @since 6.7.1
      */
     public String[] getUsedClassNames(final ConstantPool constantPool, final boolean compactClassName) {
-        String[] usedClassNames = new String[usesCount];
+        final String[] usedClassNames = new String[usesCount];
         for (int i = 0; i < usesCount; i++) {
             usedClassNames[i] = getClassNameAtIndex(constantPool, usesIndex[i], compactClassName);
         }
@@ -171,7 +183,7 @@ public final class Module extends Attribute {
     }
 
     private static String getClassNameAtIndex(final ConstantPool cp, final int index, final boolean compactClassName) {
-        String className = cp.getConstantString(index, Const.CONSTANT_Class);
+        final String className = cp.getConstantString(index, Const.CONSTANT_Class);
         if (compactClassName) {
             return Utility.compactClassName(className, false);
         }

--- a/src/main/java/org/apache/bcel/classfile/Module.java
+++ b/src/main/java/org/apache/bcel/classfile/Module.java
@@ -102,7 +102,81 @@ public final class Module extends Attribute {
         v.visitModule(this);
     }
 
-    // TODO add more getters and setters?
+    /**
+     * 
+     * @param cp Array of constants
+     * @return version from constant pool, "0" if version index is 0
+     */
+    public String getVersion(final ConstantPool cp) {
+        return moduleVersionIndex == 0 ? "0" : cp.getConstantString(moduleVersionIndex, Const.CONSTANT_Utf8);
+    }
+
+    /**
+     * 
+     * @return module flags
+     */
+    public int getModuleFlags() {
+        return moduleFlags;
+    }
+
+    /**
+     * 
+     * @param cp Array of constants
+     * @return module name
+     */
+    public String getModuleName(final ConstantPool cp) {
+        return cp.getConstantString(moduleNameIndex, Const.CONSTANT_Module);
+    }
+
+    /**
+     * @return the moduleNameIndex
+     */
+    public int getModuleNameIndex() {
+        return moduleNameIndex;
+    }
+
+    /**
+     * @return the moduleVersionIndex
+     */
+    public int getModuleVersionIndex() {
+        return moduleVersionIndex;
+    }
+
+    /**
+     * @return the usesCount
+     */
+    public int getUsesCount() {
+        return usesCount;
+    }
+
+    /**
+     * @return the usesIndex
+     */
+    public int[] getUsesIndex() {
+        return usesIndex;
+    }
+
+    /**
+     * 
+     * @param constantPool Array of constants usually obtained from the ClassFile object
+     * @param compactClassName false for original constant pool value, true to replace '/' with '.'
+     * @return array of used class names
+     */
+    public String[] getUsedClassNames(final ConstantPool constantPool, final boolean compactClassName) {
+        String[] usedClassNames = new String[usesCount];
+        for (int i = 0; i < usesCount; i++) {
+            usedClassNames[i] = getClassNameAtIndex(constantPool, usesIndex[i], compactClassName);
+        }
+        return usedClassNames;
+    }
+
+    private static String getClassNameAtIndex(final ConstantPool cp, final int index, final boolean compactClassName) {
+        String className = cp.getConstantString(index, Const.CONSTANT_Class);
+        if (compactClassName) {
+            return Utility.compactClassName(className, false);
+        }
+        return className;
+    }
 
     /**
      * @return deep copy of this attribute
@@ -207,9 +281,9 @@ public final class Module extends Attribute {
         final ConstantPool cp = super.getConstantPool();
         final StringBuilder buf = new StringBuilder();
         buf.append("Module:\n");
-        buf.append("  name:    ").append(Utility.pathToPackage(cp.getConstantString(moduleNameIndex, Const.CONSTANT_Module))).append("\n");
+        buf.append("  name:    ").append(Utility.pathToPackage(getModuleName(cp))).append("\n");
         buf.append("  flags:   ").append(String.format("%04x", moduleFlags)).append("\n");
-        final String version = moduleVersionIndex == 0 ? "0" : cp.getConstantString(moduleVersionIndex, Const.CONSTANT_Utf8);
+        final String version = getVersion(cp);
         buf.append("  version: ").append(version).append("\n");
 
         buf.append("  requires(").append(requiresTable.length).append("):\n");
@@ -229,8 +303,8 @@ public final class Module extends Attribute {
 
         buf.append("  uses(").append(usesIndex.length).append("):\n");
         for (final int index : usesIndex) {
-            final String className = cp.getConstantString(index, Const.CONSTANT_Class);
-            buf.append("    ").append(Utility.compactClassName(className, false)).append("\n");
+            final String className = getClassNameAtIndex(cp, index, true);
+            buf.append("    ").append(className).append("\n");
         }
 
         buf.append("  provides(").append(providesTable.length).append("):\n");

--- a/src/main/java/org/apache/bcel/classfile/ModuleExports.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleExports.java
@@ -54,40 +54,49 @@ public final class ModuleExports implements Cloneable, Node {
     }
 
     /**
+     * Gets the index for this ModuleExports.
      * @return the exportsIndex
+     * @since 6.7.1
      */
     public int getExportsIndex() {
         return exportsIndex;
     }
 
     /**
+     * Gets the flags for this ModuleExports.
      * @return the exportsFlags
+     * @since 6.7.1
      */
     public int getExportsFlags() {
         return exportsFlags;
     }
 
     /**
+     * Gets the number of exports for this ModuleExports.
      * @return the exportsToCount
+     * @since 6.7.1
      */
     public int getExportsToCount() {
         return exportsToCount;
     }
 
     /**
+     * Gets an array of indexes for this ModuleExports' 'exports to'.
      * @return the exportsToIndex
+     * @since 6.7.1
      */
     public int[] getExportsToIndex() {
         return exportsToIndex;
     }
 
     /**
-     * 
+     * Gets an array of module names for this ModuleExports.
      * @param constantPool Array of constants usually obtained from the ClassFile object
      * @return array of module names following 'exports to'
+     * @since 6.7.1
      */
     public String[] getToModuleNames(final ConstantPool constantPool) {
-        String[] toModuleNames = new String[exportsToCount];
+        final String[] toModuleNames = new String[exportsToCount];
         for (int i = 0; i < exportsToCount; i++) {
             toModuleNames[i] = getToModuleNameAtIndex(constantPool, exportsToIndex[i]);
         }
@@ -99,9 +108,10 @@ public final class ModuleExports implements Cloneable, Node {
     }
 
     /**
-     * 
+     * Gets the exported package name.
      * @param constantPool the constant pool from the ClassFile
      * @return the exported package name
+     * @since 6.7.1
      */
     public String getPackageName(final ConstantPool constantPool) {
         return constantPool.constantToString(exportsIndex, Const.CONSTANT_Package);

--- a/src/main/java/org/apache/bcel/classfile/ModuleExports.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleExports.java
@@ -54,6 +54,60 @@ public final class ModuleExports implements Cloneable, Node {
     }
 
     /**
+     * @return the exportsIndex
+     */
+    public int getExportsIndex() {
+        return exportsIndex;
+    }
+
+    /**
+     * @return the exportsFlags
+     */
+    public int getExportsFlags() {
+        return exportsFlags;
+    }
+
+    /**
+     * @return the exportsToCount
+     */
+    public int getExportsToCount() {
+        return exportsToCount;
+    }
+
+    /**
+     * @return the exportsToIndex
+     */
+    public int[] getExportsToIndex() {
+        return exportsToIndex;
+    }
+
+    /**
+     * 
+     * @param constantPool Array of constants usually obtained from the ClassFile object
+     * @return array of module names following 'exports to'
+     */
+    public String[] getToModuleNames(final ConstantPool constantPool) {
+        String[] toModuleNames = new String[exportsToCount];
+        for (int i = 0; i < exportsToCount; i++) {
+            toModuleNames[i] = getToModuleNameAtIndex(constantPool, exportsToIndex[i]);
+        }
+        return toModuleNames;
+    }
+
+    private static String getToModuleNameAtIndex(final ConstantPool constantPool, final int index) {
+        return constantPool.getConstantString(index, Const.CONSTANT_Module);
+    }
+
+    /**
+     * 
+     * @param constantPool the constant pool from the ClassFile
+     * @return the exported package name
+     */
+    public String getPackageName(final ConstantPool constantPool) {
+        return constantPool.constantToString(exportsIndex, Const.CONSTANT_Package);
+    }
+
+    /**
      * Called by objects that are traversing the nodes of the tree implicitly defined by the contents of a Java class.
      * I.e., the hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
      *
@@ -63,8 +117,6 @@ public final class ModuleExports implements Cloneable, Node {
     public void accept(final Visitor v) {
         v.visitModuleExports(this);
     }
-
-    // TODO add more getters and setters?
 
     /**
      * @return deep copy of this object
@@ -106,13 +158,13 @@ public final class ModuleExports implements Cloneable, Node {
      */
     public String toString(final ConstantPool constantPool) {
         final StringBuilder buf = new StringBuilder();
-        final String packageName = constantPool.constantToString(exportsIndex, Const.CONSTANT_Package);
-        buf.append(Utility.compactClassName(packageName, false));
+        final String packageName = getPackageName(constantPool);
+        buf.append(packageName);
         buf.append(", ").append(String.format("%04x", exportsFlags));
         buf.append(", to(").append(exportsToCount).append("):\n");
         for (final int index : exportsToIndex) {
-            final String moduleName = constantPool.getConstantString(index, Const.CONSTANT_Module);
-            buf.append("      ").append(Utility.compactClassName(moduleName, false)).append("\n");
+            final String moduleName = getToModuleNameAtIndex(constantPool, index);
+            buf.append("      ").append(moduleName).append("\n");
         }
         return buf.substring(0, buf.length() - 1); // remove the last newline
     }

--- a/src/main/java/org/apache/bcel/classfile/ModuleOpens.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleOpens.java
@@ -54,40 +54,49 @@ public final class ModuleOpens implements Cloneable, Node {
     }
 
     /**
+     * Gets the index for this ModuleOpens.
      * @return the opensIndex
+     * @since 6.7.1
      */
     public int getOpensIndex() {
         return opensIndex;
     }
 
     /**
+     * Gets the flags for this ModuleOpens.
      * @return the opensFlags
+     * @since 6.7.1
      */
     public int getOpensFlags() {
         return opensFlags;
     }
 
     /**
+     * Gets the number of opens for this ModuleOpens.
      * @return the opensToCount
+     * @since 6.7.1
      */
     public int getOpensToCount() {
         return opensToCount;
     }
 
     /**
+     * Gets an array of indexes for this ModuleOpens' 'opens to'.
      * @return the opensToIndex
+     * @since 6.7.1
      */
     public int[] getOpensToIndex() {
         return opensToIndex;
     }
 
     /**
-     * 
+     * Gets an array of module names for this ModuleOpens.
      * @param constantPool Array of constants usually obtained from the ClassFile object
      * @return array of module names following 'opens to'
+     * @since 6.7.1
      */
     public String[] getToModuleNames(final ConstantPool constantPool) {
-        String[] toModuleNames = new String[opensToCount];
+        final String[] toModuleNames = new String[opensToCount];
         for (int i = 0; i < opensToCount; i++) {
             toModuleNames[i] = getToModuleNameAtIndex(constantPool, opensToIndex[i]);
         }
@@ -99,9 +108,10 @@ public final class ModuleOpens implements Cloneable, Node {
     }
 
     /**
-     * 
+     * Gets the opened package name.
      * @param constantPool the constant pool from the ClassFile
      * @return the opened package name
+     * @since 6.7.1
      */
     public String getPackageName(final ConstantPool constantPool) {
         return constantPool.constantToString(opensIndex, Const.CONSTANT_Package);

--- a/src/main/java/org/apache/bcel/classfile/ModuleOpens.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleOpens.java
@@ -54,6 +54,60 @@ public final class ModuleOpens implements Cloneable, Node {
     }
 
     /**
+     * @return the opensIndex
+     */
+    public int getOpensIndex() {
+        return opensIndex;
+    }
+
+    /**
+     * @return the opensFlags
+     */
+    public int getOpensFlags() {
+        return opensFlags;
+    }
+
+    /**
+     * @return the opensToCount
+     */
+    public int getOpensToCount() {
+        return opensToCount;
+    }
+
+    /**
+     * @return the opensToIndex
+     */
+    public int[] getOpensToIndex() {
+        return opensToIndex;
+    }
+
+    /**
+     * 
+     * @param constantPool Array of constants usually obtained from the ClassFile object
+     * @return array of module names following 'opens to'
+     */
+    public String[] getToModuleNames(final ConstantPool constantPool) {
+        String[] toModuleNames = new String[opensToCount];
+        for (int i = 0; i < opensToCount; i++) {
+            toModuleNames[i] = getToModuleNameAtIndex(constantPool, opensToIndex[i]);
+        }
+        return toModuleNames;
+    }
+
+    private static String getToModuleNameAtIndex(final ConstantPool constantPool, final int index) {
+        return constantPool.getConstantString(index, Const.CONSTANT_Module);
+    }
+
+    /**
+     * 
+     * @param constantPool the constant pool from the ClassFile
+     * @return the opened package name
+     */
+    public String getPackageName(final ConstantPool constantPool) {
+        return constantPool.constantToString(opensIndex, Const.CONSTANT_Package);
+    }
+
+    /**
      * Called by objects that are traversing the nodes of the tree implicitly defined by the contents of a Java class.
      * I.e., the hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
      *
@@ -63,8 +117,6 @@ public final class ModuleOpens implements Cloneable, Node {
     public void accept(final Visitor v) {
         v.visitModuleOpens(this);
     }
-
-    // TODO add more getters and setters?
 
     /**
      * @return deep copy of this object
@@ -106,13 +158,13 @@ public final class ModuleOpens implements Cloneable, Node {
      */
     public String toString(final ConstantPool constantPool) {
         final StringBuilder buf = new StringBuilder();
-        final String packageName = constantPool.constantToString(opensIndex, Const.CONSTANT_Package);
-        buf.append(Utility.compactClassName(packageName, false));
+        final String packageName = getPackageName(constantPool);
+        buf.append(packageName);
         buf.append(", ").append(String.format("%04x", opensFlags));
         buf.append(", to(").append(opensToCount).append("):\n");
         for (final int index : opensToIndex) {
-            final String moduleName = constantPool.getConstantString(index, Const.CONSTANT_Module);
-            buf.append("      ").append(Utility.compactClassName(moduleName, false)).append("\n");
+            final String moduleName = getToModuleNameAtIndex(constantPool, index);
+            buf.append("      ").append(moduleName).append("\n");
         }
         return buf.substring(0, buf.length() - 1); // remove the last newline
     }

--- a/src/main/java/org/apache/bcel/classfile/ModuleProvides.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleProvides.java
@@ -52,34 +52,41 @@ public final class ModuleProvides implements Cloneable, Node {
     }
 
     /**
+     * Gets the index for this ModuleProvides.
      * @return the providesIndex
+     * @since 6.7.1
      */
     public int getProvidesIndex() {
         return providesIndex;
     }
 
     /**
+     * Gets the number of provides.
      * @return the providesWithCount
+     * @since 6.7.1
      */
     public int getProvidesWithCount() {
         return providesWithCount;
     }
 
     /**
+     * Gets the array of indexes for the 'provides with' clause.
      * @return the providesWithIndex
+     * @since 6.7.1
      */
     public int[] getProvidesWithIndex() {
         return providesWithIndex;
     }
 
     /**
-     * 
+     * Gets the array of implementation class names for this ModuleProvides.
      * @param constantPool Array of constants usually obtained from the ClassFile object
      * @param compactClassName false for original constant pool value, true to replace '/' with '.'
      * @return array of implementation class names
+     * @since 6.7.1
      */
     public String[] getImplementationClassNames(final ConstantPool constantPool, final boolean compactClassName) {
-        String[] implementationClassNames = new String[providesWithCount];
+        final String[] implementationClassNames = new String[providesWithCount];
         for (int i = 0; i < providesWithCount; i++) {
             implementationClassNames[i] = getImplementationClassNameAtIndex(constantPool, providesWithIndex[i], compactClassName);
         }
@@ -87,7 +94,7 @@ public final class ModuleProvides implements Cloneable, Node {
     }
 
     private static String getImplementationClassNameAtIndex(final ConstantPool constantPool, final int index, final boolean compactClassName) {
-        String className = constantPool.getConstantString(index, Const.CONSTANT_Class);
+        final String className = constantPool.getConstantString(index, Const.CONSTANT_Class);
         if (compactClassName) {
             return Utility.compactClassName(className, false);
         }
@@ -95,9 +102,10 @@ public final class ModuleProvides implements Cloneable, Node {
     }
 
     /**
-     * 
+     * Gets the interface name for this ModuleProvides.
      * @param constantPool Array of constants usually obtained from the ClassFile object
      * @return interface name
+     * @since 6.7.1
      */
     public String getInterfaceName(final ConstantPool constantPool) {
         return constantPool.constantToString(providesIndex, Const.CONSTANT_Class);

--- a/src/main/java/org/apache/bcel/classfile/ModuleProvides.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleProvides.java
@@ -52,6 +52,58 @@ public final class ModuleProvides implements Cloneable, Node {
     }
 
     /**
+     * @return the providesIndex
+     */
+    public int getProvidesIndex() {
+        return providesIndex;
+    }
+
+    /**
+     * @return the providesWithCount
+     */
+    public int getProvidesWithCount() {
+        return providesWithCount;
+    }
+
+    /**
+     * @return the providesWithIndex
+     */
+    public int[] getProvidesWithIndex() {
+        return providesWithIndex;
+    }
+
+    /**
+     * 
+     * @param constantPool Array of constants usually obtained from the ClassFile object
+     * @param compactClassName false for original constant pool value, true to replace '/' with '.'
+     * @return array of implementation class names
+     */
+    public String[] getImplementationClassNames(final ConstantPool constantPool, final boolean compactClassName) {
+        String[] implementationClassNames = new String[providesWithCount];
+        for (int i = 0; i < providesWithCount; i++) {
+            implementationClassNames[i] = getImplementationClassNameAtIndex(constantPool, providesWithIndex[i], compactClassName);
+        }
+        return implementationClassNames;
+    }
+
+    private static String getImplementationClassNameAtIndex(final ConstantPool constantPool, final int index, final boolean compactClassName) {
+        String className = constantPool.getConstantString(index, Const.CONSTANT_Class);
+        if (compactClassName) {
+            return Utility.compactClassName(className, false);
+        }
+        return className;
+    }
+
+    /**
+     * 
+     * @param constantPool Array of constants usually obtained from the ClassFile object
+     * @return interface name
+     */
+    public String getInterfaceName(final ConstantPool constantPool) {
+        return constantPool.constantToString(providesIndex, Const.CONSTANT_Class);
+    }
+
+    /**
      * Called by objects that are traversing the nodes of the tree implicitly defined by the contents of a Java class.
      * I.e., the hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
      *
@@ -61,8 +113,6 @@ public final class ModuleProvides implements Cloneable, Node {
     public void accept(final Visitor v) {
         v.visitModuleProvides(this);
     }
-
-    // TODO add more getters and setters?
 
     /**
      * @return deep copy of this object
@@ -103,12 +153,12 @@ public final class ModuleProvides implements Cloneable, Node {
      */
     public String toString(final ConstantPool constantPool) {
         final StringBuilder buf = new StringBuilder();
-        final String interfaceName = constantPool.constantToString(providesIndex, Const.CONSTANT_Class);
-        buf.append(Utility.compactClassName(interfaceName, false));
+        final String interfaceName = getInterfaceName(constantPool);
+        buf.append(interfaceName);
         buf.append(", with(").append(providesWithCount).append("):\n");
         for (final int index : providesWithIndex) {
-            final String className = constantPool.getConstantString(index, Const.CONSTANT_Class);
-            buf.append("      ").append(Utility.compactClassName(className, false)).append("\n");
+            final String className = getImplementationClassNameAtIndex(constantPool, index, true);
+            buf.append("      ").append(className).append("\n");
         }
         return buf.substring(0, buf.length() - 1); // remove the last newline
     }

--- a/src/main/java/org/apache/bcel/classfile/ModuleRequires.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleRequires.java
@@ -49,6 +49,42 @@ public final class ModuleRequires implements Cloneable, Node {
     }
 
     /**
+     * @return the requiresIndex
+     */
+    public int getRequiresIndex() {
+        return requiresIndex;
+    }
+
+    /**
+     * @return the requiresFlags
+     */
+    public int getRequiresFlags() {
+        return requiresFlags;
+    }
+
+    /**
+     * @return the requiresVersionIndex
+     */
+    public int getRequiresVersionIndex() {
+        return requiresVersionIndex;
+    }
+
+    /**
+     * @return requires version
+     */
+    public String getVersion(final ConstantPool constantPool) {
+        return requiresVersionIndex == 0 ? "0" : constantPool.getConstantString(requiresVersionIndex, Const.CONSTANT_Utf8);
+    }
+
+    /**
+     * @param constantPool Array of constants usually obtained from the ClassFile object
+     * @return module name
+     */
+    public String getModuleName(final ConstantPool constantPool) {
+        return constantPool.constantToString(requiresIndex, Const.CONSTANT_Module);
+    }
+
+    /**
      * Called by objects that are traversing the nodes of the tree implicitly defined by the contents of a Java class.
      * I.e., the hierarchy of methods, fields, attributes, etc. spawns a tree of objects.
      *
@@ -58,8 +94,6 @@ public final class ModuleRequires implements Cloneable, Node {
     public void accept(final Visitor v) {
         v.visitModuleRequires(this);
     }
-
-    // TODO add more getters and setters?
 
     /**
      * @return deep copy of this object
@@ -98,10 +132,10 @@ public final class ModuleRequires implements Cloneable, Node {
      */
     public String toString(final ConstantPool constantPool) {
         final StringBuilder buf = new StringBuilder();
-        final String moduleName = constantPool.constantToString(requiresIndex, Const.CONSTANT_Module);
-        buf.append(Utility.compactClassName(moduleName, false));
+        final String moduleName = getModuleName(constantPool);
+        buf.append(moduleName);
         buf.append(", ").append(String.format("%04x", requiresFlags));
-        final String version = requiresVersionIndex == 0 ? "0" : constantPool.getConstantString(requiresVersionIndex, Const.CONSTANT_Utf8);
+        final String version = getVersion(constantPool);
         buf.append(", ").append(version);
         return buf.toString();
     }

--- a/src/main/java/org/apache/bcel/classfile/ModuleRequires.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleRequires.java
@@ -49,36 +49,47 @@ public final class ModuleRequires implements Cloneable, Node {
     }
 
     /**
+     * Gets the index for this ModuleRequires.
      * @return the requiresIndex
+     * @since 6.7.1
      */
     public int getRequiresIndex() {
         return requiresIndex;
     }
 
     /**
+     * Gets the flags for this ModuleRequires.
      * @return the requiresFlags
+     * @since 6.7.1
      */
     public int getRequiresFlags() {
         return requiresFlags;
     }
 
     /**
+     * Gets the required version index.
      * @return the requiresVersionIndex
+     * @since 6.7.1
      */
     public int getRequiresVersionIndex() {
         return requiresVersionIndex;
     }
 
     /**
-     * @return requires version
+     * Gets the required version from the constant pool.
+     * @param constantPool Array of constants usually obtained from the ClassFile object
+     * @return required version, "0" if version index is 0.
+     * @since 6.7.1
      */
     public String getVersion(final ConstantPool constantPool) {
         return requiresVersionIndex == 0 ? "0" : constantPool.getConstantString(requiresVersionIndex, Const.CONSTANT_Utf8);
     }
 
     /**
+     * Gets the module name from the constant pool.
      * @param constantPool Array of constants usually obtained from the ClassFile object
      * @return module name
+     * @since 6.7.1
      */
     public String getModuleName(final ConstantPool constantPool) {
         return constantPool.constantToString(requiresIndex, Const.CONSTANT_Module);

--- a/src/test/java/org/apache/bcel/AnonymousClassTestCase.java
+++ b/src/test/java/org/apache/bcel/AnonymousClassTestCase.java
@@ -17,9 +17,12 @@
 
 package org.apache.bcel;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.apache.bcel.classfile.InnerClass;
+import org.apache.bcel.classfile.InnerClasses;
 import org.apache.bcel.classfile.JavaClass;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +48,14 @@ public class AnonymousClassTestCase extends AbstractTestCase {
         assertFalse(clazz.isNested(), "regular outer classes are not nested");
     }
 
+    @Test
+    public void testRegularClassInnerClasses() throws ClassNotFoundException {
+        final JavaClass clazz = getTestJavaClass(PACKAGE_BASE_NAME + ".data.AnonymousClassTest");
+        InnerClasses innerClasses = clazz.getAttribute(Const.ATTR_INNER_CLASSES);
+        InnerClass[] innerClassArray = innerClasses.getInnerClasses();
+        assertEquals(3, innerClassArray.length);
+    }
+    
     @Test
     public void testStaticInnerClassIsNotAnonymous() throws ClassNotFoundException {
         final JavaClass clazz = getTestJavaClass(PACKAGE_BASE_NAME + ".data.AnonymousClassTest$Y");

--- a/src/test/java/org/apache/bcel/LocalVariableTypeTableTestCase.java
+++ b/src/test/java/org/apache/bcel/LocalVariableTypeTableTestCase.java
@@ -21,6 +21,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.LocalVariableTypeTable;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ACONST_NULL;
 import org.apache.bcel.generic.ALOAD;
@@ -32,6 +33,7 @@ import org.apache.bcel.generic.InstructionList;
 import org.apache.bcel.generic.LocalVariableGen;
 import org.apache.bcel.generic.MethodGen;
 import org.apache.bcel.generic.Type;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class LocalVariableTypeTableTestCase extends AbstractTestCase {
@@ -142,5 +144,17 @@ public class LocalVariableTypeTableTestCase extends AbstractTestCase {
         method.invoke(null, "c1", "c2");
         method = cls.getDeclaredMethod("d", List.class, String.class);
         method.invoke(null, new LinkedList<String>(), "d2");
+    }
+
+    @Test
+    public void testGetLocalVariableTypeTable() throws ClassNotFoundException {
+        JavaClass testJavaClass = getTestJavaClass("org/apache/commons/lang3/function/TriFunction");
+        String expectedToString = "LocalVariableTypes(startPc = 0, length = 17, index = 0:org.apache.commons.lang3.function.TriFunction<T, U, V, R> this)";
+        for (Method method : testJavaClass.getMethods()) {
+            if ("lambda$andThen$0".equals(method.getName())) {
+                LocalVariableTypeTable localVariableTypeTable = method.getLocalVariableTypeTable();
+                Assertions.assertEquals(expectedToString, localVariableTypeTable.toString());
+            }
+        }
     }
 }

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolModuleAccessTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolModuleAccessTestCase.java
@@ -17,6 +17,8 @@
 package org.apache.bcel.classfile;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -32,13 +34,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Tests {@code module-info.class} files.
  */
-class ConstantPoolModuleAccessTestCase {
+public class ConstantPoolModuleAccessTestCase {
 
     @Test
-    void testJREModules() throws Exception {
-        Enumeration<URL> moduleURLs = getClass().getClassLoader().getResources("module-info.class");
+    @DisabledOnJre(value = JRE.JAVA_8)
+    public void testJREModules() throws Exception {
+        final Enumeration<URL> moduleURLs = getClass().getClassLoader().getResources("module-info.class");
         while (moduleURLs.hasMoreElements()) {
-            URL url = moduleURLs.nextElement();
+            final URL url = moduleURLs.nextElement();
             try (InputStream inputStream = url.openStream()) {
                 final ClassParser classParser = new ClassParser(inputStream, "module-info.class");
                 final JavaClass javaClass = classParser.parse();
@@ -46,13 +49,13 @@ class ConstantPoolModuleAccessTestCase {
                 final StringBuilder sb = new StringBuilder();
                 final EmptyVisitor visitor = new EmptyVisitor() {
                     @Override
-                    public void visitModule(Module obj) {
-                        String[] usedClassNames = obj.getUsedClassNames(constantPool, true);
+                    public void visitModule(final Module obj) {
+                        final String[] usedClassNames = obj.getUsedClassNames(constantPool, true);
                         if (url.getPath().contains("junit-jupiter-engine")) {
                             assertEquals(1, usedClassNames.length);
                             assertEquals("org.junit.jupiter.api.extension.Extension", usedClassNames[0]);
                         } else if (url.getPath().contains("junit-platform-launcher")) {
-                            List<String> expected = new ArrayList<>();
+                            final List<String> expected = new ArrayList<>();
                             expected.add("org.junit.platform.engine.TestEngine");
                             expected.add("org.junit.platform.launcher.LauncherDiscoveryListener");
                             expected.add("org.junit.platform.launcher.LauncherSessionListener");
@@ -66,11 +69,11 @@ class ConstantPoolModuleAccessTestCase {
                     }
 
                     @Override
-                    public void visitModuleExports(ModuleExports obj) {
-                        String packageName = obj.getPackageName(constantPool);
-                        String[] toModuleNames = obj.getToModuleNames(constantPool);
+                    public void visitModuleExports(final ModuleExports obj) {
+                        final String packageName = obj.getPackageName(constantPool);
+                        final String[] toModuleNames = obj.getToModuleNames(constantPool);
                         if (url.getPath().contains("junit-platform-commons")) {
-                            List<String> expected = new ArrayList<>();
+                            final List<String> expected = new ArrayList<>();
                             expected.add("org.junit.jupiter.api");
                             expected.add("org.junit.jupiter.engine");
                             expected.add("org.junit.jupiter.migrationsupport");
@@ -100,9 +103,9 @@ class ConstantPoolModuleAccessTestCase {
                     }
 
                     @Override
-                    public void visitModuleProvides(ModuleProvides obj) {
-                        String interfaceName = obj.getInterfaceName(constantPool);
-                        String[] implementationClassNames = obj.getImplementationClassNames(constantPool, true);
+                    public void visitModuleProvides(final ModuleProvides obj) {
+                        final String interfaceName = obj.getInterfaceName(constantPool);
+                        final String[] implementationClassNames = obj.getImplementationClassNames(constantPool, true);
                         if (url.getPath().contains("junit-jupiter-engine")) {
                             assertEquals("org.junit.platform.engine.TestEngine", interfaceName);
                             assertEquals(1, implementationClassNames.length);
@@ -116,9 +119,9 @@ class ConstantPoolModuleAccessTestCase {
                     }
                     
                     @Override
-                    public void visitModuleOpens(ModuleOpens obj) {
-                        String packageName = obj.getPackageName(constantPool);
-                        String[] toModuleNames = obj.getToModuleNames(constantPool);
+                    public void visitModuleOpens(final ModuleOpens obj) {
+                        final String packageName = obj.getPackageName(constantPool);
+                        final String[] toModuleNames = obj.getToModuleNames(constantPool);
                         if (url.getPath().contains("junit-jupiter-engine")) {
                             assertEquals("org.junit.jupiter.engine.extension", packageName);
                             assertEquals(1, toModuleNames.length);
@@ -133,10 +136,10 @@ class ConstantPoolModuleAccessTestCase {
                     }
                     
                     @Override
-                    public void visitModuleRequires(ModuleRequires obj) {
+                    public void visitModuleRequires(final ModuleRequires obj) {
                         if (url.getPath().contains("junit-jupiter-engine")) {
-                            String moduleName = obj.getModuleName(constantPool);
-                            List<String> expected = new ArrayList<>();
+                            final String moduleName = obj.getModuleName(constantPool);
+                            final List<String> expected = new ArrayList<>();
                             expected.add("java.base");
                             expected.add("org.apiguardian.api");
                             expected.add("org.junit.jupiter.api");

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolModuleAccessTestCase.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolModuleAccessTestCase.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bcel.classfile;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests {@code module-info.class} files.
+ */
+class ConstantPoolModuleAccessTestCase {
+
+    @Test
+    void testJREModules() throws Exception {
+        Enumeration<URL> moduleURLs = getClass().getClassLoader().getResources("module-info.class");
+        while (moduleURLs.hasMoreElements()) {
+            URL url = moduleURLs.nextElement();
+            try (InputStream inputStream = url.openStream()) {
+                final ClassParser classParser = new ClassParser(inputStream, "module-info.class");
+                final JavaClass javaClass = classParser.parse();
+                final ConstantPool constantPool = javaClass.getConstantPool();
+                final StringBuilder sb = new StringBuilder();
+                final EmptyVisitor visitor = new EmptyVisitor() {
+                    @Override
+                    public void visitModule(Module obj) {
+                        String[] usedClassNames = obj.getUsedClassNames(constantPool, true);
+                        if (url.getPath().contains("junit-jupiter-engine")) {
+                            assertEquals(1, usedClassNames.length);
+                            assertEquals("org.junit.jupiter.api.extension.Extension", usedClassNames[0]);
+                        } else if (url.getPath().contains("junit-platform-launcher")) {
+                            List<String> expected = new ArrayList<>();
+                            expected.add("org.junit.platform.engine.TestEngine");
+                            expected.add("org.junit.platform.launcher.LauncherDiscoveryListener");
+                            expected.add("org.junit.platform.launcher.LauncherSessionListener");
+                            expected.add("org.junit.platform.launcher.PostDiscoveryFilter");
+                            expected.add("org.junit.platform.launcher.TestExecutionListener");
+                            assertEquals(expected, Arrays.asList(usedClassNames));
+                        } else {
+                            assertEquals(0, usedClassNames.length);
+                        }
+                        super.visitModule(obj);
+                    }
+
+                    @Override
+                    public void visitModuleExports(ModuleExports obj) {
+                        String packageName = obj.getPackageName(constantPool);
+                        String[] toModuleNames = obj.getToModuleNames(constantPool);
+                        if (url.getPath().contains("junit-platform-commons")) {
+                            List<String> expected = new ArrayList<>();
+                            expected.add("org.junit.jupiter.api");
+                            expected.add("org.junit.jupiter.engine");
+                            expected.add("org.junit.jupiter.migrationsupport");
+                            expected.add("org.junit.jupiter.params");
+                            expected.add("org.junit.platform.console");
+                            expected.add("org.junit.platform.engine");
+                            expected.add("org.junit.platform.launcher");
+                            expected.add("org.junit.platform.reporting");
+                            expected.add("org.junit.platform.runner");
+                            expected.add("org.junit.platform.suite.api");
+                            switch (packageName) {
+                                case "org.junit.platform.commons.util":
+                                    expected.add("org.junit.platform.suite.commons");
+                                    // fall through
+                                case "org.junit.platform.commons.logging":
+                                    expected.add("org.junit.platform.suite.engine");
+                                    expected.add("org.junit.platform.testkit");
+                                    expected.add("org.junit.vintage.engine");
+                                    assertEquals(expected, Arrays.asList(toModuleNames));
+                                    break;
+                                default:
+                                    assertEquals(0, toModuleNames.length);
+                                    break;
+                            }
+                        }
+                        super.visitModuleExports(obj);
+                    }
+
+                    @Override
+                    public void visitModuleProvides(ModuleProvides obj) {
+                        String interfaceName = obj.getInterfaceName(constantPool);
+                        String[] implementationClassNames = obj.getImplementationClassNames(constantPool, true);
+                        if (url.getPath().contains("junit-jupiter-engine")) {
+                            assertEquals("org.junit.platform.engine.TestEngine", interfaceName);
+                            assertEquals(1, implementationClassNames.length);
+                            assertEquals("org.junit.jupiter.engine.JupiterTestEngine", implementationClassNames[0]);
+                        } else if (url.getPath().contains("junit-platform-launcher")) {
+                            assertEquals("org.junit.platform.launcher.TestExecutionListener", interfaceName);
+                            assertEquals(1, implementationClassNames.length);
+                            assertEquals("org.junit.platform.launcher.listeners.UniqueIdTrackingListener", implementationClassNames[0]);
+                        }
+                        super.visitModuleProvides(obj);
+                    }
+                    
+                    @Override
+                    public void visitModuleOpens(ModuleOpens obj) {
+                        String packageName = obj.getPackageName(constantPool);
+                        String[] toModuleNames = obj.getToModuleNames(constantPool);
+                        if (url.getPath().contains("junit-jupiter-engine")) {
+                            assertEquals("org.junit.jupiter.engine.extension", packageName);
+                            assertEquals(1, toModuleNames.length);
+                            assertEquals("org.junit.platform.commons", toModuleNames[0]);
+                        }
+                        if (url.getPath().contains("junit-jupiter-api")) {
+                            assertEquals("org.junit.jupiter.api.condition", packageName);
+                            assertEquals(1, toModuleNames.length);
+                            assertEquals("org.junit.platform.commons", toModuleNames[0]);
+                        }
+                        super.visitModuleOpens(obj);
+                    }
+                    
+                    @Override
+                    public void visitModuleRequires(ModuleRequires obj) {
+                        if (url.getPath().contains("junit-jupiter-engine")) {
+                            String moduleName = obj.getModuleName(constantPool);
+                            List<String> expected = new ArrayList<>();
+                            expected.add("java.base");
+                            expected.add("org.apiguardian.api");
+                            expected.add("org.junit.jupiter.api");
+                            expected.add("org.junit.platform.commons");
+                            expected.add("org.junit.platform.engine");
+                            expected.add("org.opentest4j");
+                            assertTrue(expected.contains(moduleName));
+                        }
+                        super.visitModuleRequires(obj);
+                    }
+                };
+                final DescendingVisitor descendingVisitor = new DescendingVisitor(javaClass, visitor);
+                try {
+                    javaClass.accept(descendingVisitor);
+                    System.out.println(sb.toString());
+                } catch (Exception | Error e) {
+                    fail(visitor.toString(), e);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/FieldAnnotationsTestCase.java
@@ -17,19 +17,22 @@
 
 package org.apache.bcel.generic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-
 import org.apache.bcel.AbstractTestCase;
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.ElementValuePair;
 import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.util.SyntheticRepository;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FieldAnnotationsTestCase extends AbstractTestCase {
     // helper methods
@@ -40,6 +43,8 @@ public class FieldAnnotationsTestCase extends AbstractTestCase {
             final AnnotationEntry[] fieldAnnotationEntrys = f.getAnnotationEntries();
             if (f.getName().equals(fieldname)) {
                 checkAnnotationEntry(fieldAnnotationEntrys[0], AnnotationEntryName, AnnotationEntryElementName, AnnotationEntryElementValue);
+                assertNotNull(f.getAttribute(Const.ATTR_RUNTIME_VISIBLE_ANNOTATIONS));
+                assertNull(f.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_ANNOTATIONS));
             }
         }
     }

--- a/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/GeneratingAnnotatedClassesTestCase.java
@@ -17,6 +17,8 @@
 package org.apache.bcel.generic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -89,6 +91,8 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase {
                 assertSimpleElementValue(annos[0]);
             }
         }
+        assertNotNull(method.getAttribute(Const.ATTR_RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS));
+        assertNull(method.getAttribute(Const.ATTR_RUNTIME_INVISIBLE_PARAMETER_ANNOTATIONS));
     }
 
     private void assertSimpleElementValue(final AnnotationEntry anno) {


### PR DESCRIPTION
- Added getters to module classes which had no accessors for their private fields (removed TODO comments)
- compactClassName only seemed to make sense for uses/provides, opens/requires/exports already had dot package separator in the constant pool
- Other getters added for various attributes