### PR TITLE
Force visit of array instructions and added comments

### DIFF
--- a/src/main/java/org/apache/bcel/util/BCELFactory.java
+++ b/src/main/java/org/apache/bcel/util/BCELFactory.java
@@ -136,6 +136,7 @@ class BCELFactory extends EmptyVisitor {
                     printWriter.print("    ");
                 }
                 if (!visitInstruction(i)) {
+                    // Do a deep visit of i if i wasn't meant to be handled directly by visitInstruction(...)
                     i.accept(this);
                 }
             }
@@ -281,7 +282,10 @@ class BCELFactory extends EmptyVisitor {
 
     private boolean visitInstruction(final Instruction i) {
         final short opcode = i.getOpcode();
-        if (InstructionConst.getInstruction(opcode) != null && !(i instanceof ConstantPushInstruction) && !(i instanceof ReturnInstruction)) { // Handled below
+        if (InstructionConst.getInstruction(opcode) != null
+          && !(i instanceof ConstantPushInstruction)
+          && !(i instanceof ReturnInstruction)
+          && !(i instanceof ArrayInstruction)) { // handle directly below, else do the deep visit with accept(...)
             printWriter.println("il.append(InstructionConst." + i.getName().toUpperCase(Locale.ENGLISH) + ");");
             return true;
         }


### PR DESCRIPTION
Array instructions were not visited because they were handled directly by visitInstruction(...). I've excluded ArrayInstruction from the scope of visitInstruction(...) so that visitArrayInstruction(...) is called through the accept(...) method.