### PR TITLE
Fix for type.getType(...) use on non-signature type names

### DIFF
--- a/src/main/java/org/apache/bcel/Const.java
+++ b/src/main/java/org/apache/bcel/Const.java
@@ -2834,7 +2834,7 @@ public final class Const {
     /**
      * The signature characters corresponding to primitive types, e.g., SHORT_TYPE_NAMES[T_INT] = "I"
      */
-    private static final String[] SHORT_TYPE_NAMES = {ILLEGAL_TYPE, ILLEGAL_TYPE, ILLEGAL_TYPE, ILLEGAL_TYPE, "Z", "C", "F", "D", "B", "S", "I", "J", "V",
+    public static final String[] SHORT_TYPE_NAMES = {ILLEGAL_TYPE, ILLEGAL_TYPE, ILLEGAL_TYPE, ILLEGAL_TYPE, "Z", "C", "F", "D", "B", "S", "I", "J", "V",
         ILLEGAL_TYPE, ILLEGAL_TYPE, ILLEGAL_TYPE};
 
     /**

--- a/src/main/java/org/apache/bcel/generic/LDC.java
+++ b/src/main/java/org/apache/bcel/generic/LDC.java
@@ -108,7 +108,7 @@ public class LDC extends CPInstruction implements PushInstruction, ExceptionThro
         case org.apache.bcel.Const.CONSTANT_Class:
             final int nameIndex = ((org.apache.bcel.classfile.ConstantClass) c).getNameIndex();
             c = cpg.getConstantPool().getConstant(nameIndex);
-            return Type.getType(((org.apache.bcel.classfile.ConstantUtf8) c).getBytes());
+            return Type.getType(Type.internalTypeNametoSignature(((org.apache.bcel.classfile.ConstantUtf8) c).getBytes()));
         default: // Never reached
             throw new IllegalArgumentException("Unknown or invalid constant type at " + super.getIndex());
         }

--- a/src/main/java/org/apache/bcel/generic/LDC.java
+++ b/src/main/java/org/apache/bcel/generic/LDC.java
@@ -108,7 +108,7 @@ public class LDC extends CPInstruction implements PushInstruction, ExceptionThro
         case org.apache.bcel.Const.CONSTANT_Class:
             final int nameIndex = ((org.apache.bcel.classfile.ConstantClass) c).getNameIndex();
             c = cpg.getConstantPool().getConstant(nameIndex);
-            return Type.getType(Type.internalTypeNametoSignature(((org.apache.bcel.classfile.ConstantUtf8) c).getBytes()));
+            return Type.getType(Type.internalTypeNameToSignature(((org.apache.bcel.classfile.ConstantUtf8) c).getBytes()));
         default: // Never reached
             throw new IllegalArgumentException("Unknown or invalid constant type at " + super.getIndex());
         }

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -366,7 +366,7 @@ public abstract class Type {
         return type ^ signature.hashCode();
     }
 
-    static String internalTypeNametoSignature(final String internalTypeName) {
+    static String internalTypeNameToSignature(final String internalTypeName) {
         if (StringUtils.isEmpty(internalTypeName) || StringUtils.equalsAny(internalTypeName, "B", "C", "D", "F", "I", "J", "S", "Z")) {
             return internalTypeName;
         }

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -25,6 +25,7 @@ import org.apache.bcel.Const;
 import org.apache.bcel.classfile.ClassFormatException;
 import org.apache.bcel.classfile.InvalidMethodSignatureException;
 import org.apache.bcel.classfile.Utility;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Abstract super class for all possible java types, namely basic types such as int, object types like String and array
@@ -363,6 +364,22 @@ public abstract class Type {
     @Override
     public int hashCode() {
         return type ^ signature.hashCode();
+    }
+
+    static String internalTypeNametoSignature(final String internalTypeName) {
+        Validate.notEmpty(internalTypeName, "Cannot call org.apache.bcel.generic.Type.internalTypeNametoSignature(String) on empty internalTypeName");
+        switch(internalTypeName.charAt(0)) {
+            case '[':
+                return internalTypeName;
+            case 'L':
+            case 'T':
+                if (internalTypeName.charAt(internalTypeName.length() - 1) == ';') {
+                    return internalTypeName;
+                }
+            // fall through
+            default:
+                return 'L' + internalTypeName + ';';
+        }
     }
 
     /**

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -367,7 +367,7 @@ public abstract class Type {
     }
 
     static String internalTypeNameToSignature(final String internalTypeName) {
-        if (StringUtils.isEmpty(internalTypeName) || StringUtils.equalsAny(internalTypeName, "B", "C", "D", "F", "I", "J", "S", "Z")) {
+        if (StringUtils.isEmpty(internalTypeName) || StringUtils.equalsAny(internalTypeName, Const.SHORT_TYPE_NAMES)) {
             return internalTypeName;
         }
         switch(internalTypeName.charAt(0)) {

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -376,7 +376,7 @@ public abstract class Type {
                 if (internalTypeName.charAt(internalTypeName.length() - 1) == ';') {
                     return internalTypeName;
                 }
-            // fall through
+                return 'L' + internalTypeName + ';';
             default:
                 return 'L' + internalTypeName + ';';
         }

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -367,7 +367,7 @@ public abstract class Type {
     }
 
     static String internalTypeNametoSignature(final String internalTypeName) {
-        if (StringUtils.isEmpty(internalTypeName) || StringUtils.equalsAny(internalTypeName, "B", "C", "D", "F", "I", "J", "S", "Z")) {
+        if (StringUtils.equalsAny(internalTypeName, "", "B", "C", "D", "F", "I", "J", "S", "Z")) {
             return internalTypeName;
         }
         switch(internalTypeName.charAt(0)) {

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -367,7 +367,7 @@ public abstract class Type {
     }
 
     static String internalTypeNametoSignature(final String internalTypeName) {
-        if (StringUtils.equalsAny(internalTypeName, "", "B", "C", "D", "F", "I", "J", "S", "Z")) {
+        if (StringUtils.isEmpty(internalTypeName) || StringUtils.equalsAny(internalTypeName, "B", "C", "D", "F", "I", "J", "S", "Z")) {
             return internalTypeName;
         }
         switch(internalTypeName.charAt(0)) {

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -370,7 +370,7 @@ public abstract class Type {
         if (StringUtils.isEmpty(internalTypeName) || StringUtils.equalsAny(internalTypeName, Const.SHORT_TYPE_NAMES)) {
             return internalTypeName;
         }
-        switch(internalTypeName.charAt(0)) {
+        switch (internalTypeName.charAt(0)) {
             case '[':
                 return internalTypeName;
             case 'L':

--- a/src/main/java/org/apache/bcel/generic/Type.java
+++ b/src/main/java/org/apache/bcel/generic/Type.java
@@ -25,7 +25,7 @@ import org.apache.bcel.Const;
 import org.apache.bcel.classfile.ClassFormatException;
 import org.apache.bcel.classfile.InvalidMethodSignatureException;
 import org.apache.bcel.classfile.Utility;
-import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Abstract super class for all possible java types, namely basic types such as int, object types like String and array
@@ -181,7 +181,7 @@ public abstract class Type {
     public static Type getType(final Class<?> cls) {
         Objects.requireNonNull(cls, "cls");
         /*
-         * That's an amzingly easy case, because getName() returns the signature. That's what we would have liked anyway.
+         * That's an amazingly easy case, because getName() returns the signature. That's what we would have liked anyway.
          */
         if (cls.isArray()) {
             return getType(cls.getName());
@@ -367,7 +367,9 @@ public abstract class Type {
     }
 
     static String internalTypeNametoSignature(final String internalTypeName) {
-        Validate.notEmpty(internalTypeName, "Cannot call org.apache.bcel.generic.Type.internalTypeNametoSignature(String) on empty internalTypeName");
+        if (StringUtils.isEmpty(internalTypeName) || StringUtils.equalsAny(internalTypeName, "B", "C", "D", "F", "I", "J", "S", "Z")) {
+            return internalTypeName;
+        }
         switch(internalTypeName.charAt(0)) {
             case '[':
                 return internalTypeName;

--- a/src/test/java/org/apache/bcel/generic/TypeTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/TypeTestCase.java
@@ -86,4 +86,16 @@ public class TypeTestCase {
             }
         }
     }
+
+    @Test
+    public void testInternalTypeNametoSignature() {
+        assertEquals(null, Type.internalTypeNametoSignature(null));
+        assertEquals("", Type.internalTypeNametoSignature(""));
+        assertEquals("TT;", Type.internalTypeNametoSignature("TT;"));
+        assertEquals("Ljava/lang/String;", Type.internalTypeNametoSignature("Ljava/lang/String;"));
+        assertEquals("[Ljava/lang/String;", Type.internalTypeNametoSignature("[Ljava/lang/String;"));
+        assertEquals("Ljava/lang/String;", Type.internalTypeNametoSignature("java/lang/String"));
+        assertEquals("I", Type.internalTypeNametoSignature("I"));
+        assertEquals("LA;", Type.internalTypeNametoSignature("A"));
+    }
 }

--- a/src/test/java/org/apache/bcel/generic/TypeTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/TypeTestCase.java
@@ -89,13 +89,13 @@ public class TypeTestCase {
 
     @Test
     public void testInternalTypeNametoSignature() {
-        assertEquals(null, Type.internalTypeNametoSignature(null));
-        assertEquals("", Type.internalTypeNametoSignature(""));
-        assertEquals("TT;", Type.internalTypeNametoSignature("TT;"));
-        assertEquals("Ljava/lang/String;", Type.internalTypeNametoSignature("Ljava/lang/String;"));
-        assertEquals("[Ljava/lang/String;", Type.internalTypeNametoSignature("[Ljava/lang/String;"));
-        assertEquals("Ljava/lang/String;", Type.internalTypeNametoSignature("java/lang/String"));
-        assertEquals("I", Type.internalTypeNametoSignature("I"));
-        assertEquals("LT;", Type.internalTypeNametoSignature("T"));
+        assertEquals(null, Type.internalTypeNameToSignature(null));
+        assertEquals("", Type.internalTypeNameToSignature(""));
+        assertEquals("TT;", Type.internalTypeNameToSignature("TT;"));
+        assertEquals("Ljava/lang/String;", Type.internalTypeNameToSignature("Ljava/lang/String;"));
+        assertEquals("[Ljava/lang/String;", Type.internalTypeNameToSignature("[Ljava/lang/String;"));
+        assertEquals("Ljava/lang/String;", Type.internalTypeNameToSignature("java/lang/String"));
+        assertEquals("I", Type.internalTypeNameToSignature("I"));
+        assertEquals("LT;", Type.internalTypeNameToSignature("T"));
     }
 }

--- a/src/test/java/org/apache/bcel/generic/TypeTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/TypeTestCase.java
@@ -96,6 +96,6 @@ public class TypeTestCase {
         assertEquals("[Ljava/lang/String;", Type.internalTypeNametoSignature("[Ljava/lang/String;"));
         assertEquals("Ljava/lang/String;", Type.internalTypeNametoSignature("java/lang/String"));
         assertEquals("I", Type.internalTypeNametoSignature("I"));
-        assertEquals("LA;", Type.internalTypeNametoSignature("A"));
+        assertEquals("LT;", Type.internalTypeNametoSignature("T"));
     }
 }

--- a/src/test/java/org/apache/bcel/generic/TypeTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/TypeTestCase.java
@@ -16,9 +16,16 @@
  */
 package org.apache.bcel.generic;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import org.apache.bcel.Repository;
+import org.apache.bcel.classfile.Code;
+import org.apache.bcel.classfile.JavaClass;
+import org.apache.bcel.classfile.Method;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TypeTestCase {
     @Test
@@ -32,4 +39,51 @@ public class TypeTestCase {
         assertEquals(expectedValue, actualValue, "Type.getType");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+    // @formatter:off
+        "java/io/Externalizable",
+        "java/io/ObjectOutputStream",
+        "java/io/Serializable",
+        "java/lang/Cloneable",
+        "java/lang/RuntimeException",
+        "java/lang/String",
+        "java/lang/System",
+        "java/lang/Throwable",
+        "java/net/URI",
+        "java/sql/Statement",
+        "java/util/ArrayList",
+        "java/util/Calendar",
+        "java/util/EnumMap",
+        "java/util/HashSet",
+        "java/util/Iterator",
+        "java/util/LinkedList",
+        "java/util/List",
+        "java/util/Map",
+        "java/util/concurrent/ConcurrentMap",
+        "java/util/concurrent/ExecutorService",
+        "org/apache/bcel/classfile/JavaClass",
+        "org/apache/bcel/classfile/Method",
+        "org/apache/bcel/classfile/Synthetic",
+        "org/apache/bcel/generic/ConstantPoolGen",
+        "org/apache/bcel/generic/MethodGen"})
+    // @formatter:on
+    public void testLDC(final String className) throws Exception {
+        final JavaClass jc = Repository.lookupClass(className);
+        final ConstantPoolGen cpg = new ConstantPoolGen(jc.getConstantPool());
+        for (final Method method : jc.getMethods()) {
+            final Code code = method.getCode();
+            if (code != null) {
+                final InstructionList instructionList = new InstructionList(code.getCode());
+                for (final InstructionHandle instructionHandle : instructionList) {
+                    instructionHandle.accept(new EmptyVisitor() {
+                        @Override
+                        public void visitLDC(LDC obj) {
+                            assertNotNull(obj.getValue(cpg));
+                        }
+                    });
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is a fix for a small regression introduced by PR #171 with the use of Type.getType(...) on an internal type name which needs to be converted to a signature first (i.e. java/lang/String => Ljava/lang/String;)