### PR TITLE
Reference actions by commit SHA

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         persist-credentials: false
-    - uses: actions/cache@v3.3.1
+    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -57,7 +57,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,7 +68,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -82,4 +82,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,17 +29,17 @@ jobs:
         java: [ 8, 11 ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         persist-credentials: false
-    - uses: actions/cache@v3.3.1
+    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3.11.0
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
@@ -47,6 +47,6 @@ jobs:
       run: mvn -V install jacoco:report -DdataFile=jacoco_jdk${{ matrix.java }}.exec --file pom.xml --no-transfer-progress
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       with:
         files: ./target/site/jacoco/jacoco.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,17 +45,17 @@ jobs:
     steps:
     - name: Prepare git
       run: git config --global core.autocrlf false
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         persist-credentials: false
-    - uses: actions/cache@v3.3.1
+    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v3.11.0
+      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
 
       - name: "Checkout code"
-        uses: actions/checkout@v3.5.2   # 3.1.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Referencing actions by commit SHA in GitHub workflows, guarantees you are using an immutable version. In contrast, actions referenced by tags and branches are vulnerable to attacks, such as the tag being moved to a malicious commit, a malicious commit being pushed to the branch or typosquatting.

Although there are pros and cons for each reference, GitHub acknowledges that [using commit SHAs is more reliable](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-shas), as does [Scorecard](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) security tool.

Currently, in this repository, we use actions such as `actions/checkout@v3.5.2` and `github/codeql-action/init@v2`. Most actions are referenced by tags. To prevent the attacks mentioned above, it would be good to change the tag references to commit SHAs as suggested in this PR.

##### Additional Context

Hi! I'm Gabriela and I work on behalf of Google and the OpenSSF suggesting supply-chain security changes :)
