### PR TITLE
[BCEL-368] Fixes java.lang.StackOverflowError in Select#toString(boolean)

### DIFF
--- a/src/main/java/org/apache/bcel/generic/Select.java
+++ b/src/main/java/org/apache/bcel/generic/Select.java
@@ -310,7 +310,11 @@ public abstract class Select extends BranchInstruction implements VariableLength
             for (int i = 0; i < match_length; i++) {
                 String s = "null";
                 if (targets[i] != null) {
-                    s = targets[i].getInstruction().toString();
+                    if (targets[i].getInstruction() == this) {
+                        s = "<points to itself>";
+                    } else {
+                        s = targets[i].getInstruction().toString();
+                    }
                 }
                 buf.append("(").append(match[i]).append(", ").append(s).append(" = {").append(indices[i]).append("})");
             }

--- a/src/test/java/org/apache/bcel/classfile/TestJira368.java
+++ b/src/test/java/org/apache/bcel/classfile/TestJira368.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 
+import org.apache.bcel.generic.InstructionList;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,20 +34,24 @@ public class TestJira368 {
     }
 
     @Test
-    public void testMethodCodeStringBrief() throws Exception {
+    public void testInstructionListStringBrief() throws Exception {
         for (Method method : parseJavaClass().getMethods()) {
-            final String string = method.getCode().toString(false);
-            // System.out.println(string);
-            assertNotNull(string);
+            if (!method.isAbstract() && !method.isNative()) {
+                final InstructionList instructionList = new InstructionList(method.getCode().getCode());
+                final String string = instructionList.toString(false);
+                assertNotNull(string);
+            }
         }
     }
 
     @Test
-    public void testMethodCodeStringVerbose() throws Exception {
+    public void testInstructionListStringVerbose() throws Exception {
         for (Method method : parseJavaClass().getMethods()) {
-            final String string = method.getCode().toString(true);
-            // System.out.println(string);
-            assertNotNull(string);
+            if (!method.isAbstract() && !method.isNative()) {
+                final InstructionList instructionList = new InstructionList(method.getCode().getCode());
+                final String string = instructionList.toString(true);
+                assertNotNull(string);
+            }
         }
     }
 


### PR DESCRIPTION
* Changed TestJira368 to test InstructionList#toString instead of Code#toString so that the test can reveal the defect in Select#toString(boolean) described in issue 368.
* Fixed issue with Select#toString(boolean) throwing a java.lang.StackOverflowError when there is a self-reference in targets. The message "<points to itself>" (choosen to be consistent with BranchInstruction#toString) is used to represent the self-reference.

Fixes: https://issues.apache.org/jira/browse/BCEL-368