### PR TITLE
Fix concurrent map access exception

### DIFF
--- a/src/main/java/org/apache/bcel/util/SyntheticRepository.java
+++ b/src/main/java/org/apache/bcel/util/SyntheticRepository.java
@@ -16,8 +16,8 @@
  */
 package org.apache.bcel.util;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This repository is used in situations where a Class is created outside the realm of a ClassLoader. Classes are loaded
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class SyntheticRepository extends MemorySensitiveClassPathRepository {
 
-    private static final Map<ClassPath, SyntheticRepository> MAP = new HashMap<>(); // CLASSPATH X REPOSITORY
+    private static final Map<ClassPath, SyntheticRepository> MAP = new ConcurrentHashMap<>(); // CLASSPATH X REPOSITORY
 
     public static SyntheticRepository getInstance() {
         return getInstance(ClassPath.SYSTEM_CLASS_PATH);


### PR DESCRIPTION
Fixes the following issue:
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.12.1:site (default-site) on project maven-builder-support: Error generating maven-project-info-reports-plugin:3.4.5:dependencies report: ConcurrentModificationException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.12.1:site (default-site) on project maven-builder-support: Error generating maven-project-info-reports-plugin:3.4.5:dependencies report
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:331)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:313)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:178)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:74)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:167)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:164)
    at org.apache.maven.lifecycle.lfv4.BuildPlanExecutor.lambda$execute$8(BuildPlanExecutor.java:186)
    at org.apache.maven.lifecycle.lfv4.PhasingExecutor.lambda$execute$0(PhasingExecutor.java:39)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
Caused by: org.apache.maven.plugin.MojoExecutionException: Error generating maven-project-info-reports-plugin:3.4.5:dependencies report
    at org.apache.maven.plugins.site.render.SiteMojo.execute(SiteMojo.java:153)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:144)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:325)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:313)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:178)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:74)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:167)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:164)
    at org.apache.maven.lifecycle.lfv4.BuildPlanExecutor.lambda$execute$8(BuildPlanExecutor.java:186)
    at org.apache.maven.lifecycle.lfv4.PhasingExecutor.lambda$execute$0(PhasingExecutor.java:39)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
Caused by: org.apache.maven.doxia.siterenderer.RendererException: Error generating maven-project-info-reports-plugin:3.4.5:dependencies report
    at org.apache.maven.plugins.site.render.ReportDocumentRenderer.renderDocument(ReportDocumentRenderer.java:247)
    at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render(DefaultSiteRenderer.java:348)
    at org.apache.maven.plugins.site.render.SiteMojo.renderLocale(SiteMojo.java:194)
    at org.apache.maven.plugins.site.render.SiteMojo.execute(SiteMojo.java:143)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:144)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:325)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:313)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:178)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:74)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:167)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:164)
    at org.apache.maven.lifecycle.lfv4.BuildPlanExecutor.lambda$execute$8(BuildPlanExecutor.java:186)
    at org.apache.maven.lifecycle.lfv4.PhasingExecutor.lambda$execute$0(PhasingExecutor.java:39)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
Caused by: java.util.ConcurrentModificationException
    at java.util.HashMap.computeIfAbsent(HashMap.java:1229)
    at org.apache.bcel.util.SyntheticRepository.getInstance(SyntheticRepository.java:42)
    at org.apache.bcel.util.SyntheticRepository.getInstance(SyntheticRepository.java:38)
    at org.apache.bcel.classfile.JavaClass.<init>(JavaClass.java:145)
    at org.apache.bcel.classfile.ClassParser.parse(ClassParser.java:178)
    at org.apache.maven.shared.jar.classes.JarClassesAnalysis.analyze(JarClassesAnalysis.java:110)
    at org.apache.maven.report.projectinfo.dependencies.Dependencies.getJarDependencyDetails(Dependencies.java:228)
    at org.apache.maven.report.projectinfo.dependencies.renderer.DependenciesRenderer.hasSealed(DependenciesRenderer.java:1158)
    at org.apache.maven.report.projectinfo.dependencies.renderer.DependenciesRenderer.renderSectionDependencyFileDetails(DependenciesRenderer.java:514)
    at org.apache.maven.report.projectinfo.dependencies.renderer.DependenciesRenderer.renderBody(DependenciesRenderer.java:229)
    at org.apache.maven.reporting.AbstractMavenReportRenderer.render(AbstractMavenReportRenderer.java:82)
    at org.apache.maven.report.projectinfo.DependenciesReport.executeReport(DependenciesReport.java:167)
    at org.apache.maven.reporting.AbstractMavenReport.generate(AbstractMavenReport.java:289)
    at org.apache.maven.plugins.site.render.ReportDocumentRenderer.renderDocument(ReportDocumentRenderer.java:226)
    at org.apache.maven.doxia.siterenderer.DefaultSiteRenderer.render(DefaultSiteRenderer.java:348)
    at org.apache.maven.plugins.site.render.SiteMojo.renderLocale(SiteMojo.java:194)
    at org.apache.maven.plugins.site.render.SiteMojo.execute(SiteMojo.java:143)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:144)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:325)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:313)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:213)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:178)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000(MojoExecutor.java:74)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run(MojoExecutor.java:167)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute(DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:164)
    at org.apache.maven.lifecycle.lfv4.BuildPlanExecutor.lambda$execute$8(BuildPlanExecutor.java:186)
    at org.apache.maven.lifecycle.lfv4.PhasingExecutor.lambda$execute$0(PhasingExecutor.java:39)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
    at java.util.concurrent.FutureTask.run(FutureTask.java:317)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
    at java.lang.Thread.run(Thread.java:1583)
Error:  
Error:  Re-run Maven using the '-X' switch to enable verbose output
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn [args] -r
Error: Process completed with exit code 1.
```