### PR TITLE
Add null guard for InstructionFactory.createInvoke()

### DIFF
--- a/src/main/java/org/apache/bcel/generic/InstructionFactory.java
+++ b/src/main/java/org/apache/bcel/generic/InstructionFactory.java
@@ -640,8 +640,10 @@ public class InstructionFactory implements InstructionConstants {
         int index;
         int nargs = 0;
         final String signature = Type.getMethodSignature(retType, argTypes);
-        for (final Type argType : argTypes) {
-            nargs += argType.getSize();
+        if (argTypes != null) {
+            for (final Type argType : argTypes) {
+                nargs += argType.getSize();
+            }
         }
         if (useInterface) {
             index = cp.addInterfaceMethodref(className, name, signature);

--- a/src/test/java/org/apache/bcel/generic/InstructionFactoryTestCase.java
+++ b/src/test/java/org/apache/bcel/generic/InstructionFactoryTestCase.java
@@ -97,4 +97,10 @@ public class InstructionFactoryTestCase extends AbstractTestCase {
         assertEquals(InstructionConst.ACONST_NULL, createNull(Type.OBJECT));
         assertEquals(InstructionConst.ACONST_NULL, createNull(Type.getType("[I")));
     }
+
+    @Test
+    public void testCreateInvokeNullArgTypes() throws Exception {
+        InstructionFactory factory = new InstructionFactory(new ClassGen(Repository.lookupClass(Object.class)));
+        factory.createInvoke("", "", Type.VOID, null, Const.INVOKESPECIAL, false); // Mustn't throw an NPE
+    }
 }


### PR DESCRIPTION
In the current implementation of the `createInvoke` method, an NPE is thrown if the `argTypes` array is `null`. This commit adds a null guard that skips the for loop if this is the case.

Example:
```java
public static void main(String args[]) {
  InstructionFactory factory= new InstructionFactory(new ClassGen(Repository.lookupClass(Object.class)));
  factory.createInvoke("", "", Type.VOID, null, Const.INVOKESPECIAL, false);
}
```
```console
Exception in thread "main" java.lang.NullPointerException
        at org.apache.bcel.generic.InstructionFactory.createInvoke(InstructionFactory.java:643)
        at Test.main(Test.java:11)
```