### PR TITLE
Update ClassParser.java

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/ClassParser.java
+++ b/src/main/java/org/apache/bcel/classfile/ClassParser.java
@@ -25,6 +25,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+import java.util.jar.JarInputStream;
+
 
 import org.apache.bcel.Const;
 
@@ -65,8 +68,9 @@ public final class ClassParser {
     public ClassParser(final InputStream inputStream, final String fileName) {
         this.fileName = fileName;
         this.fileOwned = false;
-        final String clazz = inputStream.getClass().getName(); // Not a very clean solution ...
-        this.isZip = clazz.startsWith("java.util.zip.") || clazz.startsWith("java.util.jar.");
+        
+        this.isZip = (inputStream instanceof ZipInputStream) || (inputStream instanceof JarInputStream);
+
         if (inputStream instanceof DataInputStream) {
             this.dataInputStream = (DataInputStream) inputStream;
         } else {


### PR DESCRIPTION
### Refactored `ClassParser` to Use instanceof for ZIP/JAR Detection

#### Problem:
The previous implementation used `getClass().getName()` to detect if an `InputStream` was from a ZIP/JAR file. This approach relied on string matching, which was inefficient and prone to break if class names changed.

#### Solution:
- Replaced reflection-based detection with `instanceof` checks for `ZipInputStream` and `JarInputStream`.
- Improved maintainability by eliminating unnecessary string operations.
- Added missing imports for `ZipInputStream` and `JarInputStream`.

#### Testing:
- Ran `mvn clean install` successfully.
- Verified existing tests pass.
- No breaking changes observed.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->


