### PR TITLE
Fix ConstantPoolModuleAccessTest failures on Java 25

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -69,6 +69,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action                  type="fix" dev="ggregory" due-to="Gary Gregory">Fix SpotBugs [ERROR] Medium: Operation on the "considered" shared variable in "ConstantUtf8" class is not atomic [org.apache.bcel.classfile.ConstantUtf8] At ConstantUtf8.java:[line 137] AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE.</action>
       <action                  type="fix" dev="ggregory" due-to="Gary Gregory">Fix SpotBugs [ERROR] Medium: Operation on the "skipped" shared variable in "ConstantUtf8" class is not atomic [org.apache.bcel.classfile.ConstantUtf8] At ConstantUtf8.java:[line 134] AT_NONATOMIC_OPERATIONS_ON_SHARED_VARIABLE.</action>
       <action                  type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.bcel.util.ClassPath.addJdkModules(String, List&lt;String&gt;) now reads the system property "jdk.module.path" instead of "java.modules.path"; see https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/System.html#jdk.module.path.</action>
+      <action                  type="fix" dev="iloveeclipse" due-to="Andrey Loskutov">Fix ConstantPoolModuleAccessTest failures on Java 25</action>
       <!-- ADD -->
       <action                  type="add" dev="ggregory" due-to="Gary Gregory">Add Const.MAJOR_25.</action>
       <action                  type="add" dev="ggregory" due-to="Gary Gregory">Add Const.MINOR_25.</action>

--- a/src/test/java/org/apache/bcel/classfile/ConstantPoolModuleAccessTest.java
+++ b/src/test/java/org/apache/bcel/classfile/ConstantPoolModuleAccessTest.java
@@ -161,7 +161,7 @@ public final class ConstantPoolModuleAccessTest {
                         expected.add("java.time.chrono.AbstractChronology");
                         expected.add("java.time.chrono.Chronology");
                         expected.add("java.time.zone.ZoneRulesProvider");
-                        if (javaClass.getMajor() > Const.MAJOR_11) {
+                        if (javaClass.getMajor() > Const.MAJOR_11 && javaClass.getMajor() < Const.MAJOR_24) {
                             expected.add("java.util.random.RandomGenerator");
                         }
                         expected.add("java.util.spi.CalendarDataProvider");
@@ -231,6 +231,9 @@ public final class ConstantPoolModuleAccessTest {
                             expected.add("com.sun.tools.doclint.DocLint");
                         }
                         expected.add("com.sun.tools.javac.platform.PlatformProvider");
+                        if (javaClass.getMajor() > Const.MAJOR_23) {
+                            expected.add("com.sun.tools.javac.api.JavacTrees$DocCommentTreeTransformer");
+                        }
                         assertEquals(expected, Arrays.asList(usedClassNames));
                     } else if (urlPath.contains("/jdk.jconsole/module-info.class")) {
                         final List<String> expected = new ArrayList<>();
@@ -268,6 +271,10 @@ public final class ConstantPoolModuleAccessTest {
                     } else if (urlPath.contains("/jdk.jsobject/module-info.class") && javaClass.getMajor() == Const.MAJOR_11) {
                         final List<String> expected = new ArrayList<>();
                         expected.add("jdk.internal.netscape.javascript.spi.JSObjectProvider");
+                        assertEquals(expected, Arrays.asList(usedClassNames));
+                    } else if (urlPath.contains("/jdk.jdeps/module-info.class") && javaClass.getMajor() > Const.MAJOR_24) {
+                        final List<String> expected = new ArrayList<>();
+                        expected.add("com.sun.tools.javac.platform.PlatformProvider");
                         assertEquals(expected, Arrays.asList(usedClassNames));
                     } else {
                         assertEquals(0, usedClassNames.length, () -> "Found " + Arrays.toString(usedClassNames) + " in " + urlPath);


### PR DESCRIPTION
Updated test expectations according to changes in module-info classes shipped with JDK 25.
