### PR TITLE
Use fixedLength for parsed LOOKUPSWITCH length

### DIFF
--- a/src/main/java/org/apache/bcel/generic/LOOKUPSWITCH.java
+++ b/src/main/java/org/apache/bcel/generic/LOOKUPSWITCH.java
@@ -92,8 +92,7 @@ public class LOOKUPSWITCH extends Select {
         setMatchLength(matchLength);
         final short fixedLength = (short) (9 + matchLength * 8);
         setFixedLength(fixedLength);
-        final short length = (short) (matchLength + super.getPadding());
-        super.setLength(length);
+        super.setLength((short) (fixedLength + super.getPadding()));
         super.setMatches(new int[matchLength]);
         super.setIndices(new int[matchLength]);
         super.setTargets(new InstructionHandle[matchLength]);

--- a/src/test/java/org/apache/bcel/generic/LOOKUPSWITCHTest.java
+++ b/src/test/java/org/apache/bcel/generic/LOOKUPSWITCHTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bcel.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.bcel.util.ByteSequence;
+import org.junit.jupiter.api.Test;
+
+class LOOKUPSWITCHTest {
+
+    private static byte[] lookupSwitch(final int npairs) throws IOException {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bos)) {
+            out.writeByte(org.apache.bcel.Const.LOOKUPSWITCH); // opcode at offset 0
+            out.writeByte(0); // 3 padding bytes to the next 4-byte boundary
+            out.writeByte(0);
+            out.writeByte(0);
+            out.writeInt(0); // default offset
+            out.writeInt(npairs);
+            for (int i = 0; i < npairs; i++) {
+                out.writeInt(i); // match
+                out.writeInt(i + 1); // offset
+            }
+        }
+        return bos.toByteArray();
+    }
+
+    @Test
+    void testLengthMatchesEncodedSize() throws IOException {
+        final byte[] bytes = lookupSwitch(2);
+        try (ByteSequence sequence = new ByteSequence(bytes)) {
+            final Instruction instruction = Instruction.readInstruction(sequence);
+            assertEquals(bytes.length, sequence.getIndex());
+            assertEquals(bytes.length, instruction.getLength());
+        }
+    }
+}


### PR DESCRIPTION
1. initFromFile reads matchLength, then sets the instruction length to matchLength + padding.
2. that should be fixedLength + padding, where fixedLength is 9 + matchLength * 8, so a freshly read LOOKUPSWITCH reports a length much smaller than the bytes it actually spans (a 2-pair switch consumes 28 bytes but getLength() returns 5).
TABLESWITCH.initFromFile already does fixedLength + padding; changed LOOKUPSWITCH to match. What happens if a caller reads getLength() before setPositions() runs is the part that bit me here. Added a test that reads a LOOKUPSWITCH and checks getLength() equals the consumed byte count.