### PR TITLE
Make wide flag thread-local in Utility.codeToString

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/Utility.java
+++ b/src/main/java/org/apache/bcel/classfile/Utility.java
@@ -150,9 +150,9 @@ public abstract class Utility {
     /*
      * The 'WIDE' instruction is used in the byte code to allow 16-bit wide indices for local variables. This opcode
      * precedes an 'ILOAD', for example. The opcode immediately following takes an extra byte which is combined with the following
-     * byte to form a 16-bit value.
+     * byte to form a 16-bit value. Read across consecutive codeToString() calls, so kept per-thread like CONSUMER_CHARS.
      */
-    private static boolean wide;
+    private static final ThreadLocal<Boolean> WIDE = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     // A-Z, g-z, _, $
     private static final int FREE_CHARS = 48;
@@ -428,9 +428,9 @@ public abstract class Utility {
         case Const.LLOAD:
         case Const.LSTORE:
         case Const.RET:
-            if (wide) {
+            if (WIDE.get().booleanValue()) {
                 vindex = bytes.readUnsignedShort();
-                wide = false; // Clear flag
+                WIDE.set(Boolean.FALSE); // Clear flag
             } else {
                 vindex = bytes.readUnsignedByte();
             }
@@ -441,7 +441,7 @@ public abstract class Utility {
          * called again with the following opcode.
          */
         case Const.WIDE:
-            wide = true;
+            WIDE.set(Boolean.TRUE);
             buf.append("\t(wide)");
             break;
         /*
@@ -536,10 +536,10 @@ public abstract class Utility {
          * Increment local variable.
          */
         case Const.IINC:
-            if (wide) {
+            if (WIDE.get().booleanValue()) {
                 vindex = bytes.readUnsignedShort();
                 constant = bytes.readShort();
-                wide = false;
+                WIDE.set(Boolean.FALSE);
             } else {
                 vindex = bytes.readUnsignedByte();
                 constant = bytes.readByte();

--- a/src/test/java/org/apache/bcel/classfile/UtilityTest.java
+++ b/src/test/java/org/apache/bcel/classfile/UtilityTest.java
@@ -26,9 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.bcel.Const;
 import org.apache.bcel.Repository;
+import org.apache.bcel.util.ByteSequence;
 import org.junit.jupiter.api.Test;
 
 class UtilityTest {
@@ -177,5 +179,32 @@ class UtilityTest {
                 "class signature");
         assertEquals("<K extends Object, V extends Object> extends Object",
                 Utility.signatureToString("<K:Ljava/lang/Object;V:Ljava/lang/Object;>Ljava/lang/Object;"), "class signature");
+    }
+
+    @Test
+    void testCodeToStringWideIsThreadLocal() throws Exception {
+        // A WIDE opcode disassembled on one thread must not change how the next
+        // local-variable instruction is decoded on another thread.
+        final Thread setter = new Thread(() -> {
+            try {
+                Utility.codeToString(new ByteSequence(new byte[] {(byte) Const.WIDE}), new ConstantPool(), false);
+            } catch (final Exception e) {
+                throw new AssertionError(e);
+            }
+        });
+        setter.start();
+        setter.join();
+        final AtomicReference<String> reader = new AtomicReference<>();
+        final Thread thread = new Thread(() -> {
+            try {
+                // iload with a single index byte; the trailing 0x02 must stay unread.
+                reader.set(Utility.codeToString(new ByteSequence(new byte[] {(byte) Const.ILOAD, 1, 2}), new ConstantPool(), false));
+            } catch (final Exception e) {
+                throw new AssertionError(e);
+            }
+        });
+        thread.start();
+        thread.join();
+        assertEquals("iload\t\t%1", reader.get());
     }
 }

--- a/src/test/java/org/apache/bcel/classfile/UtilityTest.java
+++ b/src/test/java/org/apache/bcel/classfile/UtilityTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
@@ -189,7 +190,7 @@ class UtilityTest {
             try {
                 Utility.codeToString(new ByteSequence(new byte[] {(byte) Const.WIDE}), new ConstantPool(), false);
             } catch (final Exception e) {
-                throw new AssertionError(e);
+                fail("WIDE disassembly failed", e);
             }
         });
         setter.start();
@@ -200,7 +201,7 @@ class UtilityTest {
                 // iload with a single index byte; the trailing 0x02 must stay unread.
                 reader.set(Utility.codeToString(new ByteSequence(new byte[] {(byte) Const.ILOAD, 1, 2}), new ConstantPool(), false));
             } catch (final Exception e) {
-                throw new AssertionError(e);
+                fail("iload disassembly failed", e);
             }
         });
         thread.start();


### PR DESCRIPTION
`Utility.codeToString` keeps the `WIDE`-prefix state in a mutable static `boolean wide`, so the flag is shared by every caller. Disassembling a `WIDE` opcode on one thread sets it, and a different thread decoding its next local-variable instruction (`iload`, `istore`, `ret`, `iinc`, ...) then reads a 2-byte index instead of 1 and misparses the rest of that method's code. The generic parser already avoids this by keeping `wide` a local in `Instruction.readInstruction`, and the adjacent `CONSUMER_CHARS` signature-parser state in this same class was likewise moved to a `ThreadLocal`. This does the same for `wide` and updates the five read/clear/set sites.

Found by comparing the two `wide` handlers. The added `UtilityTest` regression reproduces it deterministically: a `WIDE` disassembled on one thread makes an `iload` on another thread decode `%258` instead of `%1`, and it fails without the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
