### PR TITLE
Read multianewarray dimensions as unsigned byte

### DIFF
--- a/src/main/java/org/apache/bcel/generic/MULTIANEWARRAY.java
+++ b/src/main/java/org/apache/bcel/generic/MULTIANEWARRAY.java
@@ -125,7 +125,7 @@ public class MULTIANEWARRAY extends CPInstruction implements LoadClass, Allocati
     @Override
     protected void initFromFile(final ByteSequence bytes, final boolean wide) throws IOException {
         super.initFromFile(bytes, wide);
-        dimensions = bytes.readByte();
+        dimensions = (short) bytes.readUnsignedByte();
         super.setLength(4);
     }
 

--- a/src/test/java/org/apache/bcel/generic/MULTIANEWARRAYTest.java
+++ b/src/test/java/org/apache/bcel/generic/MULTIANEWARRAYTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bcel.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.bcel.Const;
+import org.apache.bcel.util.ByteSequence;
+import org.junit.jupiter.api.Test;
+
+class MULTIANEWARRAYTest {
+
+    /**
+     * The {@code dimensions} operand of {@code multianewarray} is an unsigned byte (1-255), so a value above 127 must not be
+     * read as a negative number.
+     */
+    @Test
+    void testInitFromFileReadsDimensionsUnsigned() throws Exception {
+        // multianewarray, index 0x0005, dimensions 0xC8 (200)
+        final byte[] code = {(byte) Const.MULTIANEWARRAY, 0x00, 0x05, (byte) 0xC8};
+        try (ByteSequence bytes = new ByteSequence(code)) {
+            final MULTIANEWARRAY instruction = (MULTIANEWARRAY) Instruction.readInstruction(bytes);
+            assertEquals(200, instruction.getDimensions());
+        }
+    }
+}


### PR DESCRIPTION
`MULTIANEWARRAY.initFromFile` reads the `dimensions` operand with `bytes.readByte()`, but per the JVM spec it is an unsigned byte (1-255), so a method whose `multianewarray` has `dimensions >= 128` parses into the `short` field as a sign-extended negative (200 reads back as -56), and that value then flows into `getDimensions()` and `consumeStack()`, throwing off `MethodGen.getMaxStack`. found it by comparing against `Utility.codeToString`, which already reads the same operand via `readUnsignedByte`; this mirrors that.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.