### PR TITLE
Validate index upper bound in CPInstruction, IINC and RET setIndex

### DIFF
--- a/src/main/java/org/apache/bcel/generic/CPInstruction.java
+++ b/src/main/java/org/apache/bcel/generic/CPInstruction.java
@@ -110,8 +110,8 @@ public abstract class CPInstruction extends Instruction implements TypedInstruct
      */
     @Override
     public void setIndex(final int index) { // TODO could be package-protected?
-        if (index < 0) {
-            throw new ClassGenException("Negative index value: " + index);
+        if (index < 0 || index > org.apache.bcel.Const.MAX_SHORT) {
+            throw new ClassGenException("Illegal value: " + index);
         }
         this.index = index;
     }

--- a/src/main/java/org/apache/bcel/generic/CPInstruction.java
+++ b/src/main/java/org/apache/bcel/generic/CPInstruction.java
@@ -21,6 +21,7 @@ package org.apache.bcel.generic;
 import java.io.DataOutputStream;
 import java.io.IOException;
 
+import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Constant;
 import org.apache.bcel.classfile.ConstantClass;
 import org.apache.bcel.classfile.ConstantPool;
@@ -84,7 +85,7 @@ public abstract class CPInstruction extends Instruction implements TypedInstruct
     @Override
     public Type getType(final ConstantPoolGen cpg) {
         final ConstantPool cp = cpg.getConstantPool();
-        String name = cp.getConstantString(index, org.apache.bcel.Const.CONSTANT_Class);
+        String name = cp.getConstantString(index, Const.CONSTANT_Class);
         if (!name.startsWith("[")) {
             name = "L" + name + ";";
         }

--- a/src/main/java/org/apache/bcel/generic/CPInstruction.java
+++ b/src/main/java/org/apache/bcel/generic/CPInstruction.java
@@ -111,7 +111,7 @@ public abstract class CPInstruction extends Instruction implements TypedInstruct
      */
     @Override
     public void setIndex(final int index) { // TODO could be package-protected?
-        if (index < 0 || index > org.apache.bcel.Const.MAX_SHORT) {
+        if (index < 0 || index > Const.MAX_SHORT) {
             throw new ClassGenException("Illegal value: " + index);
         }
         this.index = index;

--- a/src/main/java/org/apache/bcel/generic/CPInstruction.java
+++ b/src/main/java/org/apache/bcel/generic/CPInstruction.java
@@ -141,6 +141,6 @@ public abstract class CPInstruction extends Instruction implements TypedInstruct
         if (c instanceof ConstantClass) {
             str = Utility.packageToPath(str);
         }
-        return org.apache.bcel.Const.getOpcodeName(super.getOpcode()) + " " + str;
+        return Const.getOpcodeName(super.getOpcode()) + " " + str;
     }
 }

--- a/src/main/java/org/apache/bcel/generic/IINC.java
+++ b/src/main/java/org/apache/bcel/generic/IINC.java
@@ -135,8 +135,8 @@ public class IINC extends LocalVariableInstruction {
      */
     @Override
     public final void setIndex(final int n) {
-        if (n < 0) {
-            throw new ClassGenException("Negative index value: " + n);
+        if (n < 0 || n > Const.MAX_SHORT) {
+            throw new ClassGenException("Illegal value: " + n);
         }
         super.setIndexOnly(n);
         setWide();

--- a/src/main/java/org/apache/bcel/generic/RET.java
+++ b/src/main/java/org/apache/bcel/generic/RET.java
@@ -116,8 +116,8 @@ public class RET extends Instruction implements IndexedInstruction, TypedInstruc
      */
     @Override
     public final void setIndex(final int n) {
-        if (n < 0) {
-            throw new ClassGenException("Negative index value: " + n);
+        if (n < 0 || n > org.apache.bcel.Const.MAX_SHORT) {
+            throw new ClassGenException("Illegal value: " + n);
         }
         index = n;
         setWide();

--- a/src/test/java/org/apache/bcel/generic/SetIndexBoundsTest.java
+++ b/src/test/java/org/apache/bcel/generic/SetIndexBoundsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bcel.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.bcel.Const;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A constant pool or local variable index is encoded as a u2, so {@code setIndex} must reject a value above
+ * {@link Const#MAX_SHORT}; otherwise {@code dump} truncates it with {@code writeShort} and the emitted instruction
+ * references a different slot than requested. {@code LocalVariableInstruction.setIndex} already enforces this; these
+ * cover the siblings that did not.
+ */
+class SetIndexBoundsTest {
+
+    @Test
+    void testCpInstructionRejectsIndexAboveU2() {
+        assertEquals(Const.MAX_SHORT, new LDC_W(Const.MAX_SHORT).getIndex());
+        assertThrows(ClassGenException.class, () -> new LDC_W(Const.MAX_SHORT + 1));
+    }
+
+    @Test
+    void testIincRejectsIndexAboveU2() {
+        assertEquals(Const.MAX_SHORT, new IINC(Const.MAX_SHORT, 1).getIndex());
+        assertThrows(ClassGenException.class, () -> new IINC(Const.MAX_SHORT + 1, 1));
+    }
+
+    @Test
+    void testRetRejectsIndexAboveU2() {
+        assertEquals(Const.MAX_SHORT, new RET(Const.MAX_SHORT).getIndex());
+        assertThrows(ClassGenException.class, () -> new RET(Const.MAX_SHORT + 1));
+    }
+}


### PR DESCRIPTION
`CPInstruction.setIndex`, `IINC.setIndex` and `RET.setIndex` only reject a negative index; none check the upper bound, so an index above `Const.MAX_SHORT` (65535) is accepted and then truncated by `dump()` when it writes the operand as a u2 with `writeShort` (or a u1 with `writeByte` in the narrow forms). The emitted instruction then references a different constant-pool entry or local-variable slot than the one requested, which is the produce-arbitrary-bytecode case (CWE-787) the security page calls out for CVE-2022-42920.

`LocalVariableInstruction.setIndex` and `LocalVariableGen.setIndex` already guard `index > Const.MAX_SHORT`; this adds the same guard to the three setters that were missing it. Found while comparing the index setters across the indexed instructions. `SetIndexBoundsTest` fails on the unpatched tree (the out-of-range value is accepted) and passes after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
