### PR TITLE
Use correct attribute tag in NestHost and ModuleMainClass

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/ModuleMainClass.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleMainClass.java
@@ -59,7 +59,7 @@ public final class ModuleMainClass extends Attribute {
      * @param constantPool Array of constants.
      */
     public ModuleMainClass(final int nameIndex, final int length, final int mainClassIndex, final ConstantPool constantPool) {
-        super(Const.ATTR_NEST_MEMBERS, nameIndex, length, constantPool);
+        super(Const.ATTR_MODULE_MAIN_CLASS, nameIndex, length, constantPool);
         this.mainClassIndex = Args.requireU2(mainClassIndex, "mainClassIndex");
     }
 

--- a/src/main/java/org/apache/bcel/classfile/NestHost.java
+++ b/src/main/java/org/apache/bcel/classfile/NestHost.java
@@ -59,7 +59,7 @@ public final class NestHost extends Attribute {
      * @param constantPool Array of constants.
      */
     public NestHost(final int nameIndex, final int length, final int hostClassIndex, final ConstantPool constantPool) {
-        super(Const.ATTR_NEST_MEMBERS, nameIndex, length, constantPool);
+        super(Const.ATTR_NEST_HOST, nameIndex, length, constantPool);
         this.hostClassIndex = Args.requireU2(hostClassIndex, "hostClassIndex");
     }
 

--- a/src/test/java/org/apache/bcel/classfile/AttributeTagTest.java
+++ b/src/test/java/org/apache/bcel/classfile/AttributeTagTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bcel.classfile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.bcel.Const;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that attribute objects report their own tag via {@link Attribute#getTag()}, which {@code getAttribute(byte)}
+ * relies on for lookups.
+ */
+class AttributeTagTest {
+
+    @Test
+    void moduleMainClassReportsModuleMainClassTag() {
+        final ModuleMainClass attribute = new ModuleMainClass(0, 2, 0, new ConstantPool());
+        assertEquals(Const.ATTR_MODULE_MAIN_CLASS, attribute.getTag());
+        assertEquals("ModuleMainClass", Const.getAttributeName(attribute.getTag()));
+    }
+
+    @Test
+    void nestHostReportsNestHostTag() {
+        final NestHost attribute = new NestHost(0, 2, 0, new ConstantPool());
+        assertEquals(Const.ATTR_NEST_HOST, attribute.getTag());
+        assertEquals("NestHost", Const.getAttributeName(attribute.getTag()));
+    }
+}


### PR DESCRIPTION
`NestHost` and `ModuleMainClass` pass `Const.ATTR_NEST_MEMBERS` to the `Attribute` constructor, so a parsed attribute reports the wrong `getTag()`: a `NestHost` reports `ATTR_NEST_MEMBERS` (26) instead of `ATTR_NEST_HOST` (25), and a `ModuleMainClass` reports 26 instead of `ATTR_MODULE_MAIN_CLASS` (24). `Attribute.readAttribute` selects the right class by name, but the object then mislabels itself, so `JavaClass.getAttribute(Const.ATTR_NEST_HOST)` / `getAttribute(Const.ATTR_MODULE_MAIN_CLASS)` return `null` for a class that has those attributes, while `getAttribute(Const.ATTR_NEST_MEMBERS)` hands back a `NestHost`/`ModuleMainClass` that the unchecked cast type-confuses with `NestMembers`; `Const.getAttributeName(getTag())` also prints both as `NestMembers`. found by checking each `Attribute` subclass tag against `Const` — every other subclass passes its own constant.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
