### PR TITLE
docs: Add JavaDoc to EmptyClass

### DIFF
--- a/src/test/java/org/apache/bcel/data/EmptyClass.java
+++ b/src/test/java/org/apache/bcel/data/EmptyClass.java
@@ -19,6 +19,9 @@
 
 package org.apache.bcel.data;
 
+/**
+ * Empty class used for testing in BCEL.
+ */
 public class EmptyClass {
 }
 


### PR DESCRIPTION
### 问题背景
EmptyClass 是 Apache Commons BCEL 中的一个公共测试类，但缺少必要的 JavaDoc 文档注释。这不符合 Apache 项目通常的文档标准，尤其是对于公共 API，可能影响代码的可读性和维护性。

### 修改内容
- **修改了什么**：为 `EmptyClass` 类添加了 JavaDoc 注释，描述其用于 BCEL 测试的用途。
- **为什么这样改**：遵循 Apache 项目的文档规范，确保公共 API 具有清晰文档，便于开发者理解和使用。
- **对代码质量的提升**：增强了代码的可读性和可维护性，符合开源项目最佳实践。

### 验证方式
- 此更改仅添加注释，不改变代码逻辑，因此所有现有测试应继续通过。
- 可以手动检查源文件 `src/test/java/org/apache/bcel/data/EmptyClass.java` 以确认注释已正确添加。

### 其他信息
- 此更改不引入任何 breaking changes。
- 不需要更新额外文档，因为本 PR 本身是文档改进。
- 无已知限制。