### PR TITLE
Deep-copy bootstrap arguments array in BootstrapMethod.copy()

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/BootstrapMethod.java
+++ b/src/main/java/org/apache/bcel/classfile/BootstrapMethod.java
@@ -51,7 +51,7 @@ public class BootstrapMethod implements Cloneable {
      * @param c Source to copy.
      */
     public BootstrapMethod(final BootstrapMethod c) {
-        this(c.getBootstrapMethodRef(), c.getBootstrapArguments());
+        this(c.getBootstrapMethodRef(), c.getBootstrapArguments().clone());
     }
 
     /**
@@ -91,7 +91,9 @@ public class BootstrapMethod implements Cloneable {
      */
     public BootstrapMethod copy() {
         try {
-            return (BootstrapMethod) clone();
+            final BootstrapMethod c = (BootstrapMethod) clone();
+            c.bootstrapArguments = bootstrapArguments.clone();
+            return c;
         } catch (final CloneNotSupportedException ignore) {
             // TODO should this throw?
         }

--- a/src/test/java/org/apache/bcel/classfile/BootstrapMethodCopyTest.java
+++ b/src/test/java/org/apache/bcel/classfile/BootstrapMethodCopyTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bcel.classfile;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@link BootstrapMethod} copies do not share the mutable {@code bootstrapArguments} array with their source.
+ */
+class BootstrapMethodCopyTest {
+
+    @Test
+    void testCopyConstructorDoesNotShareArguments() {
+        final BootstrapMethod original = new BootstrapMethod(1, new int[] {10, 20, 30});
+        final BootstrapMethod copy = new BootstrapMethod(original);
+        copy.getBootstrapArguments()[0] = 999;
+        assertArrayEquals(new int[] {10, 20, 30}, original.getBootstrapArguments());
+    }
+
+    @Test
+    void testCopyDoesNotShareArguments() {
+        final BootstrapMethod original = new BootstrapMethod(1, new int[] {10, 20, 30});
+        final BootstrapMethod copy = original.copy();
+        copy.getBootstrapArguments()[0] = 999;
+        assertArrayEquals(new int[] {10, 20, 30}, original.getBootstrapArguments());
+    }
+}


### PR DESCRIPTION
`BootstrapMethod.copy()` is documented as a deep copy but returns `clone()`, which leaves the copy sharing the mutable `bootstrapArguments` int[] with its source; the copy constructor `BootstrapMethod(BootstrapMethod)` shares it too. Because `getBootstrapArguments()` returns the raw array, `setBootstrapArguments` swaps it, and `dump()` writes it, mutating a copied entry's arguments silently rewrites the original's dumped bytes. Found while checking the per-entry `copy()` contracts against `StackMapEntry.copy()`, which reallocates its arrays. Cloning the int[] in both copy paths makes each copy independent.

`ModuleExports`/`ModuleOpens`/`ModuleProvides` also `clone()` an int[], but keep it `final` with no raw getter or setter, so their aliasing is not observable and is left unchanged.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
