### PR TITLE
Use exclusive live-range end in LocalVariableTable.getLocalVariable

### DIFF
--- a/src/main/java/org/apache/bcel/classfile/LocalVariableTable.java
+++ b/src/main/java/org/apache/bcel/classfile/LocalVariableTable.java
@@ -150,7 +150,7 @@ public class LocalVariableTable extends Attribute implements Iterable<LocalVaria
             if (variable.getIndex() == index) {
                 final int startPc = variable.getStartPC();
                 final int endPc = startPc + variable.getLength();
-                if (pc >= startPc && pc <= endPc) {
+                if (pc >= startPc && pc < endPc) {
                     return variable;
                 }
             }

--- a/src/test/java/org/apache/bcel/classfile/LocalVariableTableTest.java
+++ b/src/test/java/org/apache/bcel/classfile/LocalVariableTableTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bcel.classfile;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link LocalVariableTable#getLocalVariable(int, int)}.
+ */
+class LocalVariableTableTest {
+
+    /**
+     * The live range of a local variable is the half-open interval {@code [start_pc, start_pc + length)} per JVMS 4.7.13, so a
+     * pc equal to {@code start_pc + length} is out of scope and must not match.
+     */
+    @Test
+    void testGetLocalVariableLiveRangeEndIsExclusive() {
+        final ConstantPool constantPool = new ConstantPool(new Constant[1]);
+        // Variable in slot 1, live at pcs 2, 3, 4 (start 2, length 3).
+        final LocalVariable variable = new LocalVariable(2, 3, 0, 0, 1, constantPool);
+        final LocalVariableTable table = new LocalVariableTable(0, 0, new LocalVariable[] {variable}, constantPool);
+        assertNull(table.getLocalVariable(1, 1), "pc before start");
+        assertSame(variable, table.getLocalVariable(1, 2), "pc at start");
+        assertSame(variable, table.getLocalVariable(1, 4), "pc at last valid position");
+        assertNull(table.getLocalVariable(1, 5), "pc at start + length is out of scope");
+    }
+}

--- a/src/test/java/org/apache/bcel/classfile/LocalVariableTableTest.java
+++ b/src/test/java/org/apache/bcel/classfile/LocalVariableTableTest.java
@@ -30,14 +30,15 @@ import org.junit.jupiter.api.Test;
 class LocalVariableTableTest {
 
     /**
-     * The live range of a local variable is the half-open interval {@code [start_pc, start_pc + length)} per JVMS 4.7.13, so a
-     * pc equal to {@code start_pc + length} is out of scope and must not match.
+     * The live range of a local variable is the half-open interval {@code [start_pc, start_pc + length)} per
+     * <a href="https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.7.13">JVMS 4.7.13</a>, so a pc equal to
+     * {@code start_pc + length} is out of scope and must not match.
      */
     @Test
     void testGetLocalVariableLiveRangeEndIsExclusive() {
-        final ConstantPool constantPool = new ConstantPool(new Constant[1]);
-        // Variable in slot 1, live at pcs 2, 3, 4 (start 2, length 3).
-        final LocalVariable variable = new LocalVariable(2, 3, 0, 0, 1, constantPool);
+        final ConstantPool constantPool = new ConstantPool(new Constant[] {null, new ConstantUtf8("i"), new ConstantUtf8("I")});
+        // Variable in slot 1, live at pcs 2, 3, 4 (start 2, length 3), with valid name and signature indices.
+        final LocalVariable variable = new LocalVariable(2, 3, 1, 2, 1, constantPool);
         final LocalVariableTable table = new LocalVariableTable(0, 0, new LocalVariable[] {variable}, constantPool);
         assertNull(table.getLocalVariable(1, 1), "pc before start");
         assertSame(variable, table.getLocalVariable(1, 2), "pc at start");


### PR DESCRIPTION
`LocalVariableTable.getLocalVariable(index, pc)` treats `pc == startPc + getLength()` as in scope, but JVMS 4.7.13 defines a local variable's live range as the half-open interval `[start_pc, start_pc + length)`, so a query at `start_pc + length` returns a variable that is already out of scope and reports the wrong variable as live at that program counter for a parsed class. The generation side already treats the end as exclusive (`MethodGen` derives length from `end - start`). Found while auditing the range checks in the local-variable attributes. The added test builds a variable live over `[2, 5)` and asserts `getLocalVariable(1, 5)` is `null`, which fails before the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
