### PR TITLE
Build TABLESWITCH from sorted arrays in SWITCH

### DIFF
--- a/src/main/java/org/apache/bcel/generic/SWITCH.java
+++ b/src/main/java/org/apache/bcel/generic/SWITCH.java
@@ -111,18 +111,18 @@ public final class SWITCH implements CompoundInstruction {
                 final int[] mVec = new int[maxSize];
                 final InstructionHandle[] tVec = new InstructionHandle[maxSize];
                 int count = 1;
-                mVec[0] = match[0];
-                tVec[0] = targets[0];
+                mVec[0] = matchClone[0];
+                tVec[0] = targetsClone[0];
                 for (int i = 1; i < matchLength; i++) {
-                    final int prev = match[i - 1];
-                    final int gap = match[i] - prev;
+                    final int prev = matchClone[i - 1];
+                    final int gap = matchClone[i] - prev;
                     for (int j = 1; j < gap; j++) {
                         mVec[count] = prev + j;
                         tVec[count] = target;
                         count++;
                     }
-                    mVec[count] = match[i];
-                    tVec[count] = targets[i];
+                    mVec[count] = matchClone[i];
+                    tVec[count] = targetsClone[i];
                     count++;
                 }
                 instruction = new TABLESWITCH(Arrays.copyOf(mVec, count), Arrays.copyOf(tVec, count), target);

--- a/src/test/java/org/apache/bcel/generic/SWITCHTest.java
+++ b/src/test/java/org/apache/bcel/generic/SWITCHTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bcel.generic;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+
+class SWITCHTest {
+
+    /**
+     * {@link SWITCH} documents that the key array is sorted internally while the caller's arrays are left unaltered,
+     * so an unsorted match array whose sorted form is gap-free must produce a TABLESWITCH whose case values are
+     * ascending and paired with their targets. Filling the table from the unsorted originals instead yields
+     * out-of-order match values padded with the default target.
+     */
+    @Test
+    void testUnsortedMatchBuildsSortedTableSwitch() {
+        final InstructionList il = new InstructionList();
+        final InstructionHandle defaultTarget = il.append(InstructionConst.NOP);
+        final InstructionHandle target1 = il.append(InstructionConst.NOP);
+        final InstructionHandle target2 = il.append(InstructionConst.NOP);
+        final InstructionHandle target3 = il.append(InstructionConst.NOP);
+        // Sorted form {1, 2, 3} is gap-free, so a TABLESWITCH is generated.
+        final int[] match = {2, 1, 3};
+        final InstructionHandle[] targets = {target2, target1, target3};
+        final Select select = (Select) new SWITCH(match, targets, defaultTarget).getInstruction();
+        assertInstanceOf(TABLESWITCH.class, select);
+        assertArrayEquals(new int[] {1, 2, 3}, select.getMatchs());
+        assertArrayEquals(new InstructionHandle[] {target1, target2, target3}, select.getTargets());
+    }
+}


### PR DESCRIPTION
`SWITCH` clones the caller's `match`/`targets` arrays and sorts only the clones, but the TABLESWITCH branch fills the table from the original unsorted `match`/`targets`, while the LOOKUPSWITCH branch uses `matchClone`/`targetsClone`. When the match array is passed unsorted (the class javadoc documents unsorted input and promises to leave the caller's arrays unaltered) and its sorted form is gap-free, the fill loop runs over unsorted keys, so the generated `TABLESWITCH` gets out-of-order case values padded with default entries. `TABLESWITCH.dump` then writes `low = match[0]` and `high = match[last]` that disagree with the count of offset words emitted, and re-reading the dumped instruction consumes only `high - low + 1` offsets, reinterpreting the surplus words as the next instructions.

Fill the table from `matchClone`/`targetsClone` to match the LOOKUPSWITCH branch. Found while auditing the switch-generation paths.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
