### PR TITLE
Set length in INVOKEDYNAMIC constructor

### DIFF
--- a/src/main/java/org/apache/bcel/generic/INVOKEDYNAMIC.java
+++ b/src/main/java/org/apache/bcel/generic/INVOKEDYNAMIC.java
@@ -51,6 +51,7 @@ public class INVOKEDYNAMIC extends InvokeInstruction {
      */
     public INVOKEDYNAMIC(final int index) {
         super(Const.INVOKEDYNAMIC, index);
+        super.setLength(5);
     }
 
     /**

--- a/src/test/java/org/apache/bcel/generic/INVOKEDYNAMICTest.java
+++ b/src/test/java/org/apache/bcel/generic/INVOKEDYNAMICTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bcel.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link INVOKEDYNAMIC}.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-6.html#jvms-6.5.invokedynamic">The invokedynamic instruction</a>
+ */
+class INVOKEDYNAMICTest {
+
+    /**
+     * {@code invokedynamic} occupies 5 bytes (opcode, u2 index, two zero bytes), which is what {@code dump()} writes and
+     * {@code initFromFile()} sets, so the constructed instruction must also report a length of 5.
+     */
+    @Test
+    void testConstructorSetsLength() {
+        assertEquals(5, new INVOKEDYNAMIC(1).getLength());
+    }
+
+    /**
+     * {@link InstructionList#setPositions()} adds up {@code getLength()} to place each instruction, so an understated
+     * invokedynamic length shifts the offset of every following instruction.
+     */
+    @Test
+    void testInstructionListPositionsAccountForFullLength() {
+        final InstructionList il = new InstructionList();
+        il.append(new NOP());
+        il.append(new INVOKEDYNAMIC(1));
+        final InstructionHandle after = il.append(new NOP());
+        il.setPositions();
+        // NOP (1) + invokedynamic (5) places the following NOP at offset 6
+        assertEquals(6, after.getPosition());
+    }
+}


### PR DESCRIPTION
found while checking instruction `getLength()` against `dump()`: the `INVOKEDYNAMIC(int)` constructor never sets its length, so a generated invokedynamic reports 3 while `dump()` writes 5 bytes and `InstructionList.setPositions()` then places every following instruction 2 bytes too low; mirror the sibling `INVOKEINTERFACE`/`MULTIANEWARRAY` constructors (and this class's own `initFromFile`) by calling `setLength(5)`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
