### PR TITLE
Validate u1 count bound in INVOKEINTERFACE and MULTIANEWARRAY

### DIFF
--- a/src/main/java/org/apache/bcel/generic/INVOKEINTERFACE.java
+++ b/src/main/java/org/apache/bcel/generic/INVOKEINTERFACE.java
@@ -55,8 +55,8 @@ public final class INVOKEINTERFACE extends InvokeInstruction {
     public INVOKEINTERFACE(final int index, final int nargs) {
         super(Const.INVOKEINTERFACE, index);
         super.setLength(5);
-        if (nargs < 1) {
-            throw new ClassGenException("Number of arguments must be > 0 " + nargs);
+        if (nargs < 1 || nargs > Const.MAX_BYTE) {
+            throw new ClassGenException("Number of arguments out of range (1 - " + Const.MAX_BYTE + "): " + nargs);
         }
         this.nargs = nargs;
     }

--- a/src/main/java/org/apache/bcel/generic/MULTIANEWARRAY.java
+++ b/src/main/java/org/apache/bcel/generic/MULTIANEWARRAY.java
@@ -50,7 +50,7 @@ public class MULTIANEWARRAY extends CPInstruction implements LoadClass, Allocati
      */
     public MULTIANEWARRAY(final int index, final short dimensions) {
         super(org.apache.bcel.Const.MULTIANEWARRAY, index);
-        if (dimensions < 1) {
+        if (dimensions < 1 || dimensions > org.apache.bcel.Const.MAX_BYTE) {
             throw new ClassGenException("Invalid dimensions value: " + dimensions);
         }
         this.dimensions = dimensions;

--- a/src/test/java/org/apache/bcel/generic/CountBoundsTest.java
+++ b/src/test/java/org/apache/bcel/generic/CountBoundsTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bcel.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.apache.bcel.Const;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The {@code count} operand of {@code invokeinterface} and the {@code dimensions} operand of {@code multianewarray} are
+ * both encoded as a u1, so the constructors must reject a value above {@link Const#MAX_BYTE}; otherwise {@code dump}
+ * truncates it with {@code writeByte} and the emitted instruction carries a different count than requested. The lower
+ * bound was already enforced; these cover the missing upper bound.
+ */
+class CountBoundsTest {
+
+    private static int dumpedByte(final Instruction i, final int offset) throws IOException {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(bos)) {
+            i.dump(dos);
+        }
+        return bos.toByteArray()[offset] & 0xFF;
+    }
+
+    @Test
+    void testInvokeInterfaceCountRoundTrips() throws IOException {
+        assertEquals(Const.MAX_BYTE, dumpedByte(new INVOKEINTERFACE(1, Const.MAX_BYTE), 3));
+    }
+
+    @Test
+    void testInvokeInterfaceRejectsCountAboveU1() {
+        assertEquals(Const.MAX_BYTE, new INVOKEINTERFACE(1, Const.MAX_BYTE).getCount());
+        assertThrows(ClassGenException.class, () -> new INVOKEINTERFACE(1, Const.MAX_BYTE + 1));
+    }
+
+    @Test
+    void testMultiANewArrayDimensionsRoundTrips() throws IOException {
+        assertEquals(Const.MAX_BYTE, dumpedByte(new MULTIANEWARRAY(1, (short) Const.MAX_BYTE), 3));
+    }
+
+    @Test
+    void testMultiANewArrayRejectsDimensionsAboveU1() {
+        assertEquals(Const.MAX_BYTE, new MULTIANEWARRAY(1, (short) Const.MAX_BYTE).getDimensions());
+        assertThrows(ClassGenException.class, () -> new MULTIANEWARRAY(1, (short) (Const.MAX_BYTE + 1)));
+    }
+}

--- a/src/test/java/org/apache/bcel/generic/INVOKEINTERFACETest.java
+++ b/src/test/java/org/apache/bcel/generic/INVOKEINTERFACETest.java
@@ -30,40 +30,33 @@ import org.apache.bcel.Const;
 import org.junit.jupiter.api.Test;
 
 /**
- * The {@code count} operand of {@code invokeinterface} and the {@code dimensions} operand of {@code multianewarray} are
- * both encoded as a u1, so the constructors must reject a value above {@link Const#MAX_BYTE}; otherwise {@code dump}
- * truncates it with {@code writeByte} and the emitted instruction carries a different count than requested. The lower
- * bound was already enforced; these cover the missing upper bound.
+ * Tests {@link INVOKEINTERFACE}.
+ *
+ * @see <a href="https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-6.html#jvms-6.5.invokeinterface">JVM INVOKEINTERFACE specification</a>
  */
-class CountBoundsTest {
+class INVOKEINTERFACETest {
 
-    private static int dumpedByte(final Instruction i, final int offset) throws IOException {
+    private static int dumpedCountByte(final INVOKEINTERFACE instruction) throws IOException {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         try (DataOutputStream dos = new DataOutputStream(bos)) {
-            i.dump(dos);
+            instruction.dump(dos);
         }
-        return bos.toByteArray()[offset] & 0xFF;
+        // opcode, u2 index, u1 count, u1 zero
+        return bos.toByteArray()[3] & 0xFF;
     }
 
     @Test
-    void testInvokeInterfaceCountRoundTrips() throws IOException {
-        assertEquals(Const.MAX_BYTE, dumpedByte(new INVOKEINTERFACE(1, Const.MAX_BYTE), 3));
+    void testCountRoundTrips() throws IOException {
+        assertEquals(Const.MAX_BYTE, dumpedCountByte(new INVOKEINTERFACE(1, Const.MAX_BYTE)));
     }
 
+    /**
+     * The {@code count} operand of {@code invokeinterface} is an unsigned byte (1-255) and {@code dump} writes it with {@code writeByte}, so the constructor
+     * must reject values above {@link Const#MAX_BYTE} instead of truncating them.
+     */
     @Test
-    void testInvokeInterfaceRejectsCountAboveU1() {
+    void testRejectsCountAboveU1() {
         assertEquals(Const.MAX_BYTE, new INVOKEINTERFACE(1, Const.MAX_BYTE).getCount());
         assertThrows(ClassGenException.class, () -> new INVOKEINTERFACE(1, Const.MAX_BYTE + 1));
-    }
-
-    @Test
-    void testMultiANewArrayDimensionsRoundTrips() throws IOException {
-        assertEquals(Const.MAX_BYTE, dumpedByte(new MULTIANEWARRAY(1, (short) Const.MAX_BYTE), 3));
-    }
-
-    @Test
-    void testMultiANewArrayRejectsDimensionsAboveU1() {
-        assertEquals(Const.MAX_BYTE, new MULTIANEWARRAY(1, (short) Const.MAX_BYTE).getDimensions());
-        assertThrows(ClassGenException.class, () -> new MULTIANEWARRAY(1, (short) (Const.MAX_BYTE + 1)));
     }
 }

--- a/src/test/java/org/apache/bcel/generic/MULTIANEWARRAYTest.java
+++ b/src/test/java/org/apache/bcel/generic/MULTIANEWARRAYTest.java
@@ -20,6 +20,11 @@
 package org.apache.bcel.generic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 import org.apache.bcel.Const;
 import org.apache.bcel.util.ByteSequence;
@@ -32,6 +37,20 @@ import org.junit.jupiter.api.Test;
  */
 class MULTIANEWARRAYTest {
 
+    private static int dumpedDimensionsByte(final MULTIANEWARRAY instruction) throws IOException {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (DataOutputStream dos = new DataOutputStream(bos)) {
+            instruction.dump(dos);
+        }
+        // opcode, u2 index, u1 dimensions
+        return bos.toByteArray()[3] & 0xFF;
+    }
+
+    @Test
+    void testDimensionsRoundTrips() throws IOException {
+        assertEquals(Const.MAX_BYTE, dumpedDimensionsByte(new MULTIANEWARRAY(1, (short) Const.MAX_BYTE)));
+    }
+
     /**
      * The {@code dimensions} operand of {@code multianewarray} is an unsigned byte (1-255), so a value above 127 must not be read as a negative number.
      */
@@ -43,5 +62,15 @@ class MULTIANEWARRAYTest {
             final MULTIANEWARRAY instruction = (MULTIANEWARRAY) Instruction.readInstruction(bytes);
             assertEquals(200, instruction.getDimensions());
         }
+    }
+
+    /**
+     * The {@code dimensions} operand of {@code multianewarray} is an unsigned byte (1-255) and {@code dump} writes it with {@code writeByte}, so the
+     * constructor must reject values above {@link Const#MAX_BYTE} instead of truncating them.
+     */
+    @Test
+    void testRejectsDimensionsAboveU1() {
+        assertEquals(Const.MAX_BYTE, new MULTIANEWARRAY(1, (short) Const.MAX_BYTE).getDimensions());
+        assertThrows(ClassGenException.class, () -> new MULTIANEWARRAY(1, (short) (Const.MAX_BYTE + 1)));
     }
 }


### PR DESCRIPTION
The `count` operand of `invokeinterface` and the `dimensions` operand of `multianewarray` are each a u1 (1-255), but `INVOKEINTERFACE(int, int)` and `MULTIANEWARRAY(int, short)` only check the lower bound (`nargs < 1` / `dimensions < 1`) while their `dump()` writes the field with `out.writeByte(...)`. A value in 256-32767 is accepted and returned by `getCount()`/`getDimensions()`, but truncated to its low 8 bits on dump, so the emitted instruction carries a different count than requested (e.g. `260` is written as `4`). Found while sweeping the generation-side `writeByte` sites after #506 fixed the u2 index setters. Adds the matching `> Const.MAX_BYTE` guard to both constructors; `IINC`/`RET`/`LDC` already pick a wider form so they are unaffected.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
