### PR TITLE
Bound IINC increment to signed short

### DIFF
--- a/src/main/java/org/apache/bcel/generic/IINC.java
+++ b/src/main/java/org/apache/bcel/generic/IINC.java
@@ -124,8 +124,12 @@ public class IINC extends LocalVariableInstruction {
      * Sets increment factor.
      *
      * @param c The increment factor.
+     * @throws ClassGenException if the increment is out of bounds.
      */
     public final void setIncrement(final int c) {
+        if (!isValidShort(c)) {
+            throw new ClassGenException("Illegal increment: " + c);
+        }
         this.c = c;
         setWide();
     }

--- a/src/test/java/org/apache/bcel/generic/IINCTest.java
+++ b/src/test/java/org/apache/bcel/generic/IINCTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.bcel.generic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.bcel.util.ByteSequence;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link IINC}.
+ */
+class IINCTest {
+
+    /**
+     * The increment of a wide {@code iinc} is a signed short, so a value inside that range must round-trip through
+     * {@code dump}.
+     */
+    @Test
+    void testWideIncrementRoundTrips() throws Exception {
+        final IINC iinc = new IINC(0, 30000);
+        try (ByteSequence bytes = new ByteSequence(iinc.dumpToByteArray())) {
+            assertEquals(30000, ((IINC) Instruction.readInstruction(bytes)).getIncrement());
+        }
+    }
+
+    /**
+     * {@code dump} emits the wide-form increment with {@code writeShort}, so the constructor and {@link IINC#setIncrement}
+     * must reject an increment outside the signed-short range instead of truncating it to a different value.
+     */
+    @Test
+    void testRejectsIncrementAboveShort() {
+        assertEquals(Short.MAX_VALUE, new IINC(0, Short.MAX_VALUE).getIncrement());
+        assertThrows(ClassGenException.class, () -> new IINC(0, Short.MAX_VALUE + 1));
+    }
+
+    @Test
+    void testRejectsIncrementBelowShort() {
+        assertEquals(Short.MIN_VALUE, new IINC(0, Short.MIN_VALUE).getIncrement());
+        assertThrows(ClassGenException.class, () -> new IINC(0, Short.MIN_VALUE - 1));
+    }
+
+    @Test
+    void testSetIncrementRejectsOutOfRange() {
+        final IINC iinc = new IINC(0, 1);
+        assertThrows(ClassGenException.class, () -> iinc.setIncrement(40000));
+    }
+}


### PR DESCRIPTION
`IINC.setIncrement` stores the increment without checking its range, but `dump` writes the wide-form increment with `writeShort`. The wide `iinc` increment is a signed short, so `new IINC(0, 40000)` (or `setIncrement` with any value outside `-32768..32767`) is accepted and `getIncrement` still returns `40000`, yet `dump` emits `-25536`. Found while auditing the operand setters around the earlier `setIndex` bounds fix; the increment is the one that was left unchecked.

Reject an out-of-range increment in `setIncrement` with the same `isValidShort` guard `BranchInstruction.dump` and the sibling `setIndex` already use. The two-arg constructor routes through `setIncrement`, so checking it there covers every construction path.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
